### PR TITLE
'allusers' is now the key to use in configuration conditionalPackageMapSpecs to indicate that the maps apply to --all users--

### DIFF
--- a/rowan/configs/Load.ston
+++ b/rowan/configs/Load.ston
@@ -33,7 +33,7 @@
 				#defaultSymbolDictName : 'RowanKernel',
 				#defaultUseSessionMethodsForExtensions : false
 				},
-			'default' : {
+			'allusers' : {
 				#defaultSymbolDictName : 'UserGlobals',
 				#defaultUseSessionMethodsForExtensions : false
 				}

--- a/rowan/src/Rowan-Configurations/RwProjectLoadConfigurationVisitor.class.st
+++ b/rowan/src/Rowan-Configurations/RwProjectLoadConfigurationVisitor.class.st
@@ -73,23 +73,26 @@ RwProjectLoadConfigurationVisitor >> _processConditionalPackageMapSpecs: aProjec
 			ifTrue: [
 				(thePackageMapSpecsMap 
 					at: currentUserId 
-					ifAbsent: [ thePackageMapSpecsMap at: 'default'  ifAbsent: [] ])
-						ifNotNil: [:thePackageMapSpecs |
-							(thePackageMapSpecs at: #defaultSymbolDictName otherwise: nil) 
-								ifNotNil: [:name | packageMapSpecs at: #defaultSymbolDictName put: name ].
-							(thePackageMapSpecs at: #defaultUseSessionMethodsForExtensions otherwise: nil) 
-								ifNotNil: [:boolean | packageMapSpecs at: #defaultUseSessionMethodsForExtensions put: boolean  ].
-							(thePackageMapSpecs at: #packageNameToPlatformPropertiesMap otherwise: nil) 
-								ifNotNil: [:theMap | 
-									| map |
-									map := packageMapSpecs at: #packageNameToPlatformPropertiesMap ifAbsentPut: [ Dictionary new ].
-									theMap keysAndValuesDo: [:thePackageName :thePropMap | 
-										thePropMap keysAndValuesDo: [:thePropertyName :thePropertyValue |
-											| packageMap |
-											packageMap  := map at: thePackageName ifAbsentPut: [ Dictionary new ].
-											(#('symbolDictName' 'userId' 'useSessionMethodsForExtensions' ) includes: thePropertyName)
-												ifTrue: [ packageMap at: thePropertyName put: thePropertyValue  ] 
-												ifFalse: [ self error: 'Unrecognized property name ', thePropertyName printString, ' in package name to properties map' ] ] ] ] ] ] ]
+					ifAbsent: [ 
+						"<allusers> is preferred, but for the alpha, there are outstanding configs that use <default>"
+						thePackageMapSpecsMap at: 'default'  
+							ifAbsent: [ thePackageMapSpecsMap at: 'allusers'  ifAbsent: [] ] ])
+								ifNotNil: [:thePackageMapSpecs |
+									(thePackageMapSpecs at: #defaultSymbolDictName otherwise: nil) 
+										ifNotNil: [:name | packageMapSpecs at: #defaultSymbolDictName put: name ].
+									(thePackageMapSpecs at: #defaultUseSessionMethodsForExtensions otherwise: nil) 
+										ifNotNil: [:boolean | packageMapSpecs at: #defaultUseSessionMethodsForExtensions put: boolean  ].
+									(thePackageMapSpecs at: #packageNameToPlatformPropertiesMap otherwise: nil) 
+										ifNotNil: [:theMap | 
+											| map |
+											map := packageMapSpecs at: #packageNameToPlatformPropertiesMap ifAbsentPut: [ Dictionary new ].
+											theMap keysAndValuesDo: [:thePackageName :thePropMap | 
+												thePropMap keysAndValuesDo: [:thePropertyName :thePropertyValue |
+													| packageMap |
+													packageMap  := map at: thePackageName ifAbsentPut: [ Dictionary new ].
+													(#('symbolDictName' 'userId' 'useSessionMethodsForExtensions' ) includes: thePropertyName)
+														ifTrue: [ packageMap at: thePropertyName put: thePropertyValue  ] 
+														ifFalse: [ self error: 'Unrecognized property name ', thePropertyName printString, ' in package name to properties map' ] ] ] ] ] ] ]
 
 ]
 

--- a/rowan/src/Rowan-GemStone-Core/RwPackage.extension.st
+++ b/rowan/src/Rowan-GemStone-Core/RwPackage.extension.st
@@ -13,12 +13,6 @@ RwPackage >> symbolDictName [
 ]
 
 { #category : '*rowan-gemstone-core' }
-RwPackage >> userId [
-
-	^ self _gemstonePlatformSpec userIdForPackageNamed: self name
-]
-
-{ #category : '*rowan-gemstone-core' }
 RwPackage >> useSessionMethodsForExtensions [
 
 	^ self _gemstonePlatformSpec

--- a/rowan/src/Rowan-GemStone-Core/RwProject.extension.st
+++ b/rowan/src/Rowan-GemStone-Core/RwProject.extension.st
@@ -7,12 +7,6 @@ RwProject >> defaultSymbolDictName [
 ]
 
 { #category : '*rowan-gemstone-core' }
-RwProject >> defaultUserId [
-
-	^ self _gemstonePlatformSpec defaultUserId
-]
-
-{ #category : '*rowan-gemstone-core' }
 RwProject >> defaultUseSessionMethodsForExtensions [
 
 	^ self _gemstonePlatformSpec defaultUseSessionMethodsForExtensions
@@ -28,12 +22,6 @@ RwProject >> methodEnvForPackageNamed: packageName [
 RwProject >> symbolDictNameForPackageNamed: packageName [
 
 	^ self _gemstonePlatformSpec symbolDictNameForPackageNamed: packageName
-]
-
-{ #category : '*rowan-gemstone-core' }
-RwProject >> userIdForPackageNamed: packageName [
-
-	^ self _gemstonePlatformSpec userIdForPackageNamed: packageName
 ]
 
 { #category : '*rowan-gemstone-core' }

--- a/rowan/src/Rowan-GemStone-Specifications/RwGemStoneSpecification.class.st
+++ b/rowan/src/Rowan-GemStone-Specifications/RwGemStoneSpecification.class.st
@@ -4,7 +4,6 @@ Class {
 	#instVars : [
 		'defaultMethodEnv',
 		'defaultSymbolDictName',
-		'defaultUserId',
 		'defaultUseSessionMethodsForExtensions',
 		'packageNameToPlatformPropertiesMap',
 		'projectOwnerId'
@@ -34,18 +33,6 @@ RwGemStoneSpecification >> defaultSymbolDictName [
 RwGemStoneSpecification >> defaultSymbolDictName: aString [
 
 	defaultSymbolDictName := aString
-]
-
-{ #category : 'accessing' }
-RwGemStoneSpecification >> defaultUserId [
-
-	^ defaultUserId ifNil: [ defaultUserId := Rowan image currentUserId ]
-]
-
-{ #category : 'accessing' }
-RwGemStoneSpecification >> defaultUserId: aString [
-
-	defaultUserId := aString
 ]
 
 { #category : 'accessing' }
@@ -186,16 +173,6 @@ RwGemStoneSpecification >> userId: userId forPackageNamed: packageName [
 		at: packageName
 		ifAbsent: [ packageNameToPlatformPropertiesMap at: packageName put: Dictionary new ].
 	packageProperties at: 'userId' put: userId
-]
-
-{ #category : 'accessing' }
-RwGemStoneSpecification >> userIdForPackageNamed: packageName [
-
-	| packageProperties |
-	packageProperties := packageNameToPlatformPropertiesMap
-		at: packageName
-		ifAbsent: [ ^ self defaultUserId ].
-	^ packageProperties at: 'userId' ifAbsent: [ ^ self defaultUserId ]
 ]
 
 { #category : 'accessing' }

--- a/test/configs/RowanNestedCoreProjectLoadConfiguration.ston
+++ b/test/configs/RowanNestedCoreProjectLoadConfiguration.ston
@@ -103,7 +103,7 @@
 					'Rowan-GemStone-Loader' : { 'symbolDictName' : 'RowanLoader' }
 					}
 			},
-			'default' : {
+			'allusers' : {
 				#defaultSymbolDictName : 'UserGlobals',
 				#defaultUseSessionMethodsForExtensions : false
 				}

--- a/test/configs/RowanProjectLoadConfiguration.ston
+++ b/test/configs/RowanProjectLoadConfiguration.ston
@@ -125,7 +125,7 @@
 					'Rowan-GemStone-Loader' : { 'symbolDictName' : 'RowanLoader' }
 					}
 			},
-			'default' : {
+			'allusers' : {
 				#defaultSymbolDictName : 'UserGlobals',
 				#defaultUseSessionMethodsForExtensions : false
 				}

--- a/test/configs/RowanSampleProject4_LoadConfiguration.ston
+++ b/test/configs/RowanSampleProject4_LoadConfiguration.ston
@@ -38,7 +38,7 @@
 		},
 	#conditionalPackageMapSpecs : {
 		'gemstone' : {
-			'default' : {
+			'allusers' : {
 				#defaultSymbolDictName : 'RowanSample4SymbolDict',
 				#defaultUseSessionMethodsForExtensions : false,
 				#packageNameToPlatformPropertiesMap : {


### PR DESCRIPTION
... except those users that are explicitly specified

### Test Status
```
292 run, 284 passed, 3 failed, 5 errors
  errors
	RwHybridBrowserToolTest>>#testHybridMoveClassToPackageInAlternaterSymbolDict
	RwHybridBrowserToolTest>>#testHybridMoveMethodFromSessionMethodsIntoSessionMethods
	RwHybridBrowserToolTest>>#testHybridMoveMethodIntoSessionMethods
	RwRowanProjectIssuesTest>>#testIssue150_branches
	RwRowanSample4Test>>#testIssue230
  failures
	RwLoadingTest>>#testPoolDictionaryChanges
	RwRowanProjectIssuesTest>>#testIssue123_moveExistingClassWithMethodsAndSubclassesToNewPackageAndNewClassVersion
	RwSymbolDictionaryTest>>#testClassVersioningPatch
```