### PR TITLE
Adjustments needed to run the reconcile/adopt/load scripts as a non-DataCurator/SystemUser user (RowanTools symbol dictionary NOT in symbol list)

### DIFF
--- a/platforms/gemstone/projects/ston/src/STON-Core/STONReaderError.class.st
+++ b/platforms/gemstone/projects/ston/src/STON-Core/STONReaderError.class.st
@@ -9,6 +9,9 @@ Class {
 	#instVars : [
 		'streamPosition'
 	],
+	#gs_options : [
+		'disallowGciStore'
+	],
 	#category : 'STON-Core'
 }
 

--- a/platforms/gemstone/projects/ston/src/STON-Core/STONWriterError.class.st
+++ b/platforms/gemstone/projects/ston/src/STON-Core/STONWriterError.class.st
@@ -5,5 +5,8 @@ Class {
 	#name : 'STONWriterError',
 	#superclass : 'Error',
 	#type : 'variable',
+	#gs_options : [
+		'disallowGciStore'
+	],
 	#category : 'STON-Core'
 }

--- a/platforms/gemstone/projects/ston/src/STON-GemStoneBase/STONReader.extension.st
+++ b/platforms/gemstone/projects/ston/src/STON-GemStoneBase/STONReader.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'STONReader' }
 STONReader >> lookupClass: name [
   ^ (System myUserProfile objectNamed: name asSymbol)
     ifNil: [ 
-		(((AllUsers userWithId: 'SystemUser') objectNamed: 'RowanKernel')
+		(((AllUsers userWithId: 'SystemUser') objectNamed: 'RowanTools')
 			ifNotNil: [:rowanSymbolDictionary |
 				(rowanSymbolDictionary at: name asSymbol ifAbsent: [])
 					ifNotNil: [:cls | ^cls ] ])

--- a/platforms/gemstone/topaz/3.2.15/ston/STON-GemStoneBase-Core.gs
+++ b/platforms/gemstone/topaz/3.2.15/ston/STON-GemStoneBase-Core.gs
@@ -140,7 +140,7 @@ method: STONReader
 lookupClass: name
   ^ (System myUserProfile objectNamed: name asSymbol)
     ifNil: [ 
-		(((AllUsers userWithId: 'SystemUser') objectNamed: 'RowanKernel')
+		(((AllUsers userWithId: 'SystemUser') objectNamed: 'RowanTools')
 			ifNotNil: [:rowanSymbolDictionary |
 				(rowanSymbolDictionary at: name asSymbol ifAbsent: [])
 					ifNotNil: [:cls | ^cls ] ])

--- a/rowan/src/Rowan-Tools-Core/RwPrjCreateTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjCreateTool.class.st
@@ -70,6 +70,21 @@ RwPrjCreateTool >> createDiskBasedProject: projectName packageNames: packageName
 ]
 
 { #category : 'project definition creation' }
+RwPrjCreateTool >> createDiskBasedProjectDefinition: projectName packageNames: packageNames format: format root: rootPath [
+	"Create a new project definition for a disk-based Rowan project with the given attributes"
+
+	| utils rootRepoPath |
+	utils := self fileUtilities.
+	rootRepoPath := rootPath , utils pathNameDelimiter , projectName.
+	^ (RwProjectDefinition newForDiskBasedProjectNamed: projectName)
+		packageNames: packageNames;
+		repositoryRootPath: rootRepoPath;
+		projectOwnerId: Rowan image currentUserId;
+		yourself.
+
+]
+
+{ #category : 'project definition creation' }
 RwPrjCreateTool >> createDiskBasedProjectDefinition: projectName packageNames: packageNames format: format root: rootPath configsPath: configsPath repoPath: repoPath specsPath: specsPath [
 	"Create a new project definition for a disk-based Rowan project with the given attributes"
 
@@ -125,6 +140,21 @@ RwPrjCreateTool >> createGitBasedProject: projectName packageNames: packageNames
 	^ self
 		createProjectFor: projectDefinition 
 		format: format
+
+]
+
+{ #category : 'project definition creation' }
+RwPrjCreateTool >> createGitBasedProjectDefinition: projectName packageNames: packageNames format: format root: rootPath [
+	"Create a new project definition for a git-based Rowan project with the given attributes"
+
+	| utils rootRepoPath |
+	utils := self fileUtilities.
+	rootRepoPath := rootPath , utils pathNameDelimiter , projectName.
+	^(RwProjectDefinition newForGitBasedProjectNamed: projectName)
+		packageNames: packageNames;
+		repositoryRootPath: rootRepoPath;
+		projectOwnerId: Rowan image currentUserId;
+		yourself.
 
 ]
 


### PR DESCRIPTION
needed to add a simpler way to get a project definition that is not going to show up on disk  (i.e., the Staging Project when doing an adopt)...

STONReader needs to lookup classes in RowanTools symbol dictionary to load configurations and specs