### PR TITLE
Fix for #242 and tweaks to #165 and #213

### DIFF
--- a/rowan/src/Rowan-GemStone-Core/RwGsImage.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsImage.class.st
@@ -313,20 +313,12 @@ RwGsImage class >> loadedProjectNamed: aString ifAbsent: absentBlock [
 	currentUserId := self currentUserId.
 	^ self _loadedProjectRegistry
 		at: aString
-		ifAbsent: [ 
-			AllUsers
-				do: [ :userProfile | 
-					userProfile defaultObjectSecurityPolicy currentUserCanRead
-						ifTrue: [
-							| aUserId |
-							aUserId := userProfile userId.
-							aUserId ~= currentUserId
-								ifTrue: [ 
-									(self _loadedProjectRegistryForUserId: aUserId)
-										ifNotNil: [ :projectRegistry | 
-											(projectRegistry at: aString ifAbsent: [  ])
-												ifNotNil: [ :loadedProject | ^ loadedProject ] ] ] ] ].
-			^ absentBlock value ]
+		ifAbsent: [
+			| matchingProjects |
+			matchingProjects := self loadedProjects select: [:each | each name = aString ].
+			matchingProjects size > 1 ifTrue: [ self error: 'Multiple projects with same name available from symbol dictionaries in symbol list' ].
+			matchingProjects size = 0 ifTrue: [ ^ absentBlock value ].
+			matchingProjects any ]
 
 ]
 
@@ -345,12 +337,7 @@ RwGsImage class >> loadedProjects [
 				do: [:loadedPackage | 
 					"visible loaded projects"
 					loadedProjects add: loadedPackage loadedProject ] ].
-	loadedProjects := loadedProjects 
-		reject: [:loadedProject | 
-			"if a package is visible in the symbol list (visible package registries), but the loaded project
-				is not in one of the loaded project registries, then ignore the project"
-			(self loadedProjectNamed: loadedProject name ifAbsent: []) isNil ].
-	^ loadedProjects
+	^loadedProjects
 
 ]
 

--- a/rowan/src/Rowan-GemStone-Core/RwGsImage.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsImage.class.st
@@ -16,8 +16,13 @@ RwGsImage class >> _loadedProjectRegistry [
 { #category : 'private' }
 RwGsImage class >> _loadedProjectRegistryForUserId: aUserId [
 
-	| ug |
-	ug := (AllUsers userWithId: aUserId) objectNamed: #'UserGlobals'.
+	| userProfile ug |
+	userProfile := AllUsers userWithId: aUserId.
+	userProfile defaultObjectSecurityPolicy currentUserCanRead
+		ifFalse: [
+			"do not have permissions to read objects created by <aUserId>"
+			^ nil ].
+	ug := userProfile objectNamed: #'UserGlobals'.
 	^ ug
 		at: #'RwGsLoadedProjectRegistry'
 		ifAbsent: [ 
@@ -311,14 +316,16 @@ RwGsImage class >> loadedProjectNamed: aString ifAbsent: absentBlock [
 		ifAbsent: [ 
 			AllUsers
 				do: [ :userProfile | 
-					| aUserId |
-					aUserId := userProfile userId.
-					aUserId ~= currentUserId
-						ifTrue: [ 
-							(self _loadedProjectRegistryForUserId: aUserId)
-								ifNotNil: [ :projectRegistry | 
-									(projectRegistry at: aString ifAbsent: [  ])
-										ifNotNil: [ :loadedProject | ^ loadedProject ] ] ] ].
+					userProfile defaultObjectSecurityPolicy currentUserCanRead
+						ifTrue: [
+							| aUserId |
+							aUserId := userProfile userId.
+							aUserId ~= currentUserId
+								ifTrue: [ 
+									(self _loadedProjectRegistryForUserId: aUserId)
+										ifNotNil: [ :projectRegistry | 
+											(projectRegistry at: aString ifAbsent: [  ])
+												ifNotNil: [ :loadedProject | ^ loadedProject ] ] ] ] ].
 			^ absentBlock value ]
 
 ]

--- a/rowan/src/Rowan-Tests/RwAbstractTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAbstractTest.class.st
@@ -658,5 +658,7 @@ RwAbstractTest >> setUp [
 RwAbstractTest >> tearDown [
 
 	super tearDown.
-	Rowan platform _alternateImageClass: nil
+	Rowan platform _alternateImageClass: nil.
+	self class cleanup.
+
 ]


### PR DESCRIPTION
### Fixed issues
issue #242 - Rowan Load problem with a user with a world-none security policy

### Updated fixes for previously closed issues
issue #213 - Projects list should be derived from the transient symbol list ...
issue #165 - `Rowan class>>packageNames` should return packages that are registered with symbol dictionaries in the current user's symbol list

### Test Status
```
292 run, 283 passed, 3 failed, 6 errors
  errors
	RwHybridBrowserToolTest>>#testHybridMoveClassToPackageInAlternaterSymbolDict
	RwHybridBrowserToolTest>>#testHybridMoveMethodFromSessionMethodsIntoSessionMethods
	RwHybridBrowserToolTest>>#testHybridMoveMethodIntoSessionMethods
	RwRowanProjectIssuesTest>>#testIssue150_branches
	RwRowanSample2Test>>#testNoMigration_gitolite
	RwRowanSample4Test>>#testIssue230
  failures
	RwLoadingTest>>#testPoolDictionaryChanges
	RwRowanProjectIssuesTest>>#testIssue123_moveExistingClassWithMethodsAndSubclassesToNewPackageAndNewClassVersion
	RwSymbolDictionaryTest>>#testClassVersioningPatch
```