### PR TITLE
Alpha14 release candidate merge to master

### DIFF
--- a/platforms/gemstone/bin/packing
+++ b/platforms/gemstone/bin/packing
@@ -26,6 +26,7 @@ set -e
 # Alpha9: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha9 v0.4.0-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha10: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha10 v0.4.1-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha12: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha12 v0.4.3-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
+# Alpha13: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha13 v0.4.4-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -268,14 +268,14 @@ RowanProjectService >> removeProjectNamed: projectName [
 { #category : 'rowan' }
 RowanProjectService >> repositorySha [
 
-	^(RwProject newNamed: name) repositoryCommitId
+	^ [ (RwProject newNamed: name) repositoryCommitId ] on: Error do: [:ex | ^'ERROR getting repository commit id' ]
 
 ]
 
 { #category : 'rowan' }
 RowanProjectService >> rowanBranch [
 
-	^(RwProject newNamed: name) currentBranchName
+	^ [ (RwProject newNamed: name) currentBranchName ] on: Error do: [:ex | ^'ERROR getting repository branch' ]
 
 ]
 

--- a/rowan/src/Rowan-Tools-Core/RwGitTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwGitTool.class.st
@@ -37,8 +37,9 @@ RwGitTool >> gitBranchNameIn: gitRepoPath [
 
 	| command result |
 	command := 'set -e; cd ' , gitRepoPath , '; git rev-parse --abbrev-ref HEAD'.
-	result := System performOnServer: command.
+	result := self performOnServer: command logging: false.
 	^ result trimWhiteSpace
+
 ]
 
 { #category : 'smalltalk api' }

--- a/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
@@ -131,6 +131,13 @@ RwPrjBrowserTool >> _projectNamed: projectName [
 	^ (self _loadedProjectNamed: projectName) asDefinition
 ]
 
+{ #category : 'private' }
+RwPrjBrowserTool >> _rowanSymbolDictionaryNames [
+
+	^ #( #RowanKernel #RowanLoader #RowanTools )
+
+]
+
 { #category : 'class browsing' }
 RwPrjBrowserTool >> addOrUpdateClassDefinition: className type: type superclass: superclassName instVarNames: anArrayOfStrings classVars: anArrayOfClassVars classInstVars: anArrayOfClassInstVars poolDictionaries: anArrayOfPoolDicts category: category packageName: packageName constraints: constraintsArray options: optionsArray [
 
@@ -388,6 +395,27 @@ RwPrjBrowserTool >> addPackagesNamed: packageNames toProjectNamed: projectName [
 	packageNames
 		do: [ :packageName | projectDefinition addPackage: (RwPackageDefinition newNamed: packageName) ].
 	Rowan projectTools load loadProjectDefinition: projectDefinition
+]
+
+{ #category : 'project browsing' }
+RwPrjBrowserTool >> addRowanSymbolDictionariesToPeristentSymbolList [
+
+	self addRowanSymbolDictionariesToPeristentSymbolListFor: System myUserProfile
+
+]
+
+{ #category : 'project browsing' }
+RwPrjBrowserTool >> addRowanSymbolDictionariesToPeristentSymbolListFor: userProfile [
+
+	| systemUser |
+	systemUser := AllUsers userWithId: 'SystemUser'.
+	self _rowanSymbolDictionaryNames do: [:symDictName |
+		| aSymbolDictionary anIndex |
+		aSymbolDictionary := systemUser objectNamed: symDictName.
+		anIndex := userProfile symbolList size + 1.
+		userProfile
+			insertDictionary: aSymbolDictionary at: anIndex ]
+
 ]
 
 { #category : 'class browsing' }


### PR DESCRIPTION
### fixes
1. Issue #224 - Support for adding Rowan symbol dictionaries to persistent symbol list
  ```smalltalk 
   Rowan projectTools browser addRowanSymbolDictionariesToPeristentSymbolList
   Rowan projectTools browser 
      addRowanSymbolDictionariesToPeristentSymbolListFor: 
        (AllUsers userWithId: 'userId')
  ```
2. Issue #280 - Error: No loaded package named 'Rowan-Services-Tests' found to Error: No loaded package named 'Rowan-Services-Tests' found -- doing diff against Rowan
   - turns out that this is *deep* Jadeite Alpha2.0.1 error, but Issue #224 can be used as workaround.
3. Issue #281 - Better handling in `Project Tool` when git repository is missing on disk
   - short term patch implemented that eliminates walkback