### PR TITLE
Alpha16 release candidate merge to master 

### DIFF
--- a/platforms/gemstone/bin/packing
+++ b/platforms/gemstone/bin/packing
@@ -28,6 +28,7 @@ set -e
 # Alpha12: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha12 v0.4.3-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha13: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha13 v0.4.4-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha14: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha14 v0.4.5-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
+# Alpha15: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha15 v0.4.6-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"

--- a/rowan/src/Rowan-Core/RwDeleteClassFromSystemNotification.class.st
+++ b/rowan/src/Rowan-Core/RwDeleteClassFromSystemNotification.class.st
@@ -13,15 +13,16 @@ Class {
 
 { #category : 'accessing' }
 RwDeleteClassFromSystemNotification >> candidateClass [
+	"class to be deleted from system, if receiver is #resumed: with true"
 
 	^ candidateClass
 
 ]
 
 { #category : 'accessing' }
-RwDeleteClassFromSystemNotification >> candidateClass: aClass [
+RwDeleteClassFromSystemNotification >> candidateClass: aClassToBeDeleted [
 
-	candidateClass := aClass
+	candidateClass := aClassToBeDeleted
 
 ]
 

--- a/rowan/src/Rowan-Core/RwExecuteClassInitializeMethodsAfterLoadNotification.class.st
+++ b/rowan/src/Rowan-Core/RwExecuteClassInitializeMethodsAfterLoadNotification.class.st
@@ -2,11 +2,29 @@ Class {
 	#name : 'RwExecuteClassInitializeMethodsAfterLoadNotification',
 	#superclass : 'RwNotification',
 	#type : 'variable',
+	#instVars : [
+		'candidateClass'
+	],
 	#gs_options : [
 		'disallowGciStore'
 	],
 	#category : 'Rowan-Core'
 }
+
+{ #category : 'accessing' }
+RwExecuteClassInitializeMethodsAfterLoadNotification >> candidateClass [
+	"class to which #initialize if receiver is #resumed: with true"
+
+	^ candidateClass
+
+]
+
+{ #category : 'accessing' }
+RwExecuteClassInitializeMethodsAfterLoadNotification >> candidateClass: aClassToInitialize [
+
+	candidateClass := aClassToInitialize
+
+]
 
 { #category : 'handling' }
 RwExecuteClassInitializeMethodsAfterLoadNotification >> defaultAction [

--- a/rowan/src/Rowan-GemStone-Core/RwGsDeferredInstanceMigrator.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsDeferredInstanceMigrator.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : 'RwGsDeferredInstanceMigrator',
+	#superclass : 'RwGsInstanceMigrator',
+	#instVars : [
+		'classesToMigrate'
+	],
+	#category : 'Rowan-GemStone-Core'
+}
+
+{ #category : 'accessing' }
+RwGsDeferredInstanceMigrator >> classesToMigrate [
+
+	^ classesToMigrate
+
+]
+
+{ #category : 'migration' }
+RwGsDeferredInstanceMigrator >> migrateInstancesOf: aClassArray [
+
+	"Record the list of classes with new class versions"
+
+	classesToMigrate := aClassArray
+
+]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassConstraintsSymDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassConstraintsSymDictPatch.class.st
@@ -15,6 +15,13 @@ RwGsClassConstraintsSymDictPatch >> addToNewClassesByName: aDictionary [
 { #category : 'installing' }
 RwGsClassConstraintsSymDictPatch >> installPropertiesPatchFor: aPatchSet [
 
+	self installPropertiesPatchFor: aPatchSet registry: self symbolDictionaryRegistry
+
+]
+
+{ #category : 'installing' }
+RwGsClassConstraintsSymDictPatch >> installPropertiesPatchFor: aPatchSet registry: aSymbolDictionaryRegistry [
+
 	" update class and update loadedClass with new constraints"
 
 	| className existingClass theConstraints existingConstraintsMap existingVaryingConstraint theConstraintsMap theVaryingConstraint keys |
@@ -63,6 +70,6 @@ RwGsClassConstraintsSymDictPatch >> installPropertiesPatchFor: aPatchSet [
 		ifFalse: [
 			"change the varying constraint"
 			existingClass _setVaryingConstraint: theVaryingConstraint ].
-	self symbolDictionaryRegistry updateClassProperties: existingClass implementationClass: RwGsSymbolDictionaryRegistry_Implementation.
+	aSymbolDictionaryRegistry updateClassProperties: existingClass implementationClass: RwGsSymbolDictionaryRegistry_Implementation.
 
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassPatch.class.st
@@ -164,6 +164,14 @@ RwGsClassPatch >> createClassFor: aPatchSet [
 	^ createdClass
 ]
 
+{ #category : 'patching moved classes' }
+RwGsClassPatch >> installPropertiesPatchFor: aPatchSet classMove: aClassMove [
+
+
+	self installPropertiesPatchFor: aPatchSet registry: (self symbolDictionaryRegistryFor: aClassMove packageAfter name)
+
+]
+
 { #category : 'versioning' }
 RwGsClassPatch >> oldClassVersion [
 	"The old version is what is currently bound to the class definition's name."

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassPatch.class.st
@@ -167,6 +167,7 @@ RwGsClassPatch >> createClassFor: aPatchSet [
 { #category : 'patching moved classes' }
 RwGsClassPatch >> installPropertiesPatchFor: aPatchSet classMove: aClassMove [
 
+(UserGlobals at: #ConditionalHalt ifAbsent: [ false ]) ifTrue: [ self halt ].
 
 	self installPropertiesPatchFor: aPatchSet registry: (self symbolDictionaryRegistryFor: aClassMove packageAfter name)
 

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassPropertiesSymDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassPropertiesSymDictPatch.class.st
@@ -23,6 +23,13 @@ RwGsClassPropertiesSymDictPatch >> addToNewClassesByName: aDictionary [
 { #category : 'installing' }
 RwGsClassPropertiesSymDictPatch >> installPropertiesPatchFor: aPatchSet [
 
+	self installPropertiesPatchFor: aPatchSet registry: self symbolDictionaryRegistry
+
+]
+
+{ #category : 'installing' }
+RwGsClassPropertiesSymDictPatch >> installPropertiesPatchFor: aPatchSet registry: aSymbolDictionaryRegistry [
+
 	" update class and update loadedClass with new properties"
 
 	| className existingClass createdClass |
@@ -39,6 +46,6 @@ RwGsClassPropertiesSymDictPatch >> installPropertiesPatchFor: aPatchSet [
 			self
 				error:
 					'internal error - class changed during class property update ... should have been a class versioning patch' ].
-	self symbolDictionaryRegistry updateClassProperties: existingClass implementationClass: RwGsSymbolDictionaryRegistry_Implementation
+	aSymbolDictionaryRegistry updateClassProperties: existingClass implementationClass: RwGsSymbolDictionaryRegistry_Implementation
 
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassVariableChangeSymbolDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassVariableChangeSymbolDictPatch.class.st
@@ -32,6 +32,13 @@ RwGsClassVariableChangeSymbolDictPatch >> createClassFor: aPatchSet [
 { #category : 'installing' }
 RwGsClassVariableChangeSymbolDictPatch >> installPropertiesPatchFor: aPatchSet [
 
+	self installPropertiesPatchFor: aPatchSet registry: self symbolDictionaryRegistry
+
+]
+
+{ #category : 'installing' }
+RwGsClassVariableChangeSymbolDictPatch >> installPropertiesPatchFor: aPatchSet registry: aSymbolDictionaryRegistry [
+
 	" update class and update loadedClass with new properties"
 
 	| className existingClass |
@@ -42,6 +49,6 @@ RwGsClassVariableChangeSymbolDictPatch >> installPropertiesPatchFor: aPatchSet [
 			aPatchSet tempSymbols
 				at: className
 				ifAbsent: [ self error: 'Cannot find class to update properties for.' ] ].
-	self symbolDictionaryRegistry updateClassProperties: existingClass  implementationClass: RwGsSymbolDictionaryRegistry_Implementation
+	aSymbolDictionaryRegistry updateClassProperties: existingClass  implementationClass: RwGsSymbolDictionaryRegistry_Implementation
 
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningPatch.class.st
@@ -192,7 +192,7 @@ RwGsClassVersioningPatch >> addPatchedClassModification: aClassModification inPa
 	newFormat := self
 		_classFormat: existingClass superclass format
 		forSubclassType: afterClassDefinition classType.
-	afterSymDict := afterClassDefinition gs_symbolDictionary ifNil: [ self symbolDictionary name asString ].
+	afterSymDict := self symbolDictionary name asString.
 	beforeSymDict := beforeClassDefinition gs_symbolDictionary.
 	beforeSymDict ~= afterSymDict
 		ifTrue: [

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningSymbolDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningSymbolDictPatch.class.st
@@ -190,12 +190,24 @@ RwGsClassVersioningSymbolDictPatch >> existingSymbolDictionaryRegistry [
 ]
 
 { #category : 'patching' }
-RwGsClassVersioningSymbolDictPatch >> installNewClassVerionInSystem [
+RwGsClassVersioningSymbolDictPatch >> installNewClassVersionInSystem [
 
 	"Install the new class association in the symbolAssociation for the class.
 	 Update the LoadedClass with properties for the new classversion."
 
 	self symbolDictionaryRegistry addNewClassVersionToAssociation: newClassVersion implementationClass: RwGsSymbolDictionaryRegistry_Implementation
+
+]
+
+{ #category : 'patching' }
+RwGsClassVersioningSymbolDictPatch >> moveNewClassVersionInSystem: aClassMove [
+
+	"Move the class association for the class.
+	 Update the LoadedClass with properties for the new classversion."
+
+	(self symbolDictionaryRegistryFor: aClassMove packageAfter name)
+		addNewClassVersionToAssociation: newClassVersion 
+		implementationClass: RwGsSymbolDictionaryRegistry_Implementation
 
 ]
 

--- a/rowan/src/Rowan-GemStone-Loader/RwGsMethodDeletionExtensionSessionMethodSymbolDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsMethodDeletionExtensionSessionMethodSymbolDictPatch.class.st
@@ -81,12 +81,5 @@ RwGsMethodDeletionExtensionSessionMethodSymbolDictPatch >> deleteNewVersionMetho
 { #category : 'accessing' }
 RwGsMethodDeletionExtensionSessionMethodSymbolDictPatch >> symbolDictionary [
 
-	| symDictName symDict |
-	symDictName := self projectDefinition
-		symbolDictNameForPackageNamed: self packageName.
-	symDict := GsCurrentSession currentSession symbolList objectNamed: symDictName asSymbol.
-	symDict
-		ifNotNil: [ symDict rowanSymbolDictionaryRegistry ifNotNil: [ ^ symDict ] ].
-	^ Rowan image newOrExistingSymbolDictionaryNamed: symDictName
-
+	^self symbolDictionaryFor: self packageName
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatch.class.st
@@ -58,9 +58,16 @@ RwGsPatch >> resolveName: aName [
 { #category : 'accessing' }
 RwGsPatch >> symbolDictionary [
 
+	^ self symbolDictionaryFor: self packageName
+
+]
+
+{ #category : 'accessing' }
+RwGsPatch >> symbolDictionaryFor: aPackageName [
+
 	| symDictName symDict |
 	symDictName := self projectDefinition
-		symbolDictNameForPackageNamed: self packageName.
+		symbolDictNameForPackageNamed:aPackageName.
 	symDict := GsCurrentSession currentSession symbolList objectNamed: symDictName asSymbol.
 	symDict
 		ifNotNil: [ symDict rowanSymbolDictionaryRegistry ifNotNil: [ ^ symDict ] ].
@@ -72,4 +79,12 @@ RwGsPatch >> symbolDictionary [
 RwGsPatch >> symbolDictionaryRegistry [
 
 	^ self symbolDictionary rowanSymbolDictionaryRegistry
+
+]
+
+{ #category : 'accessing' }
+RwGsPatch >> symbolDictionaryRegistryFor: aPackageName [
+
+	^ (self symbolDictionaryFor: aPackageName) rowanSymbolDictionaryRegistry
+
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet.class.st
@@ -1287,5 +1287,6 @@ RwGsPatchSet >> updateMethodProperties [
 RwGsPatchSet >> updateSymbolAssociations [
 	"Install new class versions."
 
-	classesWithNewVersions do: [:each | each installNewClassVerionInSystem ]
+	classesWithNewVersions do: [:each | each installNewClassVersionInSystem ]
+
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
@@ -1276,5 +1276,10 @@ RwGsPatchSet_254 >> updateMethodProperties [
 RwGsPatchSet_254 >> updateSymbolAssociations [
 	"Install new class versions."
 
-	classesWithNewVersions do: [:each | each installNewClassVerionInSystem ]
+	classesWithNewVersions do: [:each | 
+		(movedClassesMap at: each className ifAbsent: [])
+			ifNil: [ each installNewClassVersionInSystem ]
+			ifNotNil: [:aClassMove | each moveNewClassVersionInSystem: aClassMove ].
+		 ]
+
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
@@ -1164,8 +1164,9 @@ RwGsPatchSet_254 >> runInitializers [
 		ifTrue: [ self class methodPatchesInInitializationOrder: methodPatches ]
 		ifFalse: [ methodPatches ].
 	orderedMethodPatches do: [ :methodPatch | 
-			RwExecuteClassInitializeMethodsAfterLoadNotification signal 
-				ifTrue: [ methodPatch runInitializer ] ]
+			(RwExecuteClassInitializeMethodsAfterLoadNotification new
+				candidateClass: methodPatch behavior thisClass) signal 
+					ifTrue: [ methodPatch runInitializer ] ]
 
 ]
 

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
@@ -1247,7 +1247,10 @@ RwGsPatchSet_254 >> updateClassProperties [
 	(classesWithClassVariableChanges copy
 		addAll: classesWithPropertyChanges;
 		addAll: classesWithConstraintChanges;
-		yourself) do: [ :each | each installPropertiesPatchFor: self ]
+		yourself) do: [ :each | 
+			(movedClassesMap at: each className ifAbsent: [])
+				ifNil: [ each installPropertiesPatchFor: self ]
+				ifNotNil: [:aClassMove | each installPropertiesPatchFor: self classMove: aClassMove ] ]
 
 ]
 

--- a/rowan/src/Rowan-Tests/RwHybridBrowserToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwHybridBrowserToolTest.class.st
@@ -1071,7 +1071,6 @@ RwHybridBrowserToolTest >> testHybridMoveClassToPackageInAlternaterSymbolDict [
 	self assert: movedNormalClass == normalClass.
 	self assert: movedNormalClass rowanPackageName = packageName2
 
-
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwHybridBrowserToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwHybridBrowserToolTest.class.st
@@ -1034,7 +1034,7 @@ RwHybridBrowserToolTest >> testHybridMoveClassToPackage [
 { #category : 'tests' }
 RwHybridBrowserToolTest >> testHybridMoveClassToPackageInAlternaterSymbolDict [
 
-	| normalClass projectName packageNames packageName1 packageName2 movedNormalClass packageNameMap |
+	| normalClass projectName packageNames packageName1 packageName2 movedNormalClass packageNameMap symDict registry |
 	projectName := 'Hybrid Project A'.
 	packageName1 := 'HybridA-Core'.
 	packageName2 := 'HybridA-Extensions'.
@@ -1059,6 +1059,23 @@ RwHybridBrowserToolTest >> testHybridMoveClassToPackageInAlternaterSymbolDict [
 		category: packageName1
 		options: #().
 	self assert: normalClass rowanPackageName = packageName1.
+	self assert: normalClass category= packageName1.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
 
 	movedNormalClass := Object
 		rwSubclass: 'SimpleHybridNormal1'
@@ -1068,8 +1085,268 @@ RwHybridBrowserToolTest >> testHybridMoveClassToPackageInAlternaterSymbolDict [
 		poolDictionaries: #()
 		category: packageName2
 		options: #().
+
 	self assert: movedNormalClass == normalClass.
-	self assert: movedNormalClass rowanPackageName = packageName2
+	self assert: movedNormalClass rowanPackageName = packageName2.
+	self assert: movedNormalClass category= packageName2.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+]
+
+{ #category : 'tests' }
+RwHybridBrowserToolTest >> testHybridMoveClassToPackageInAlternaterSymbolDict_class_vars [
+
+	| normalClass projectName packageNames packageName1 packageName2 movedNormalClass packageNameMap symDict registry |
+	projectName := 'Hybrid Project A'.
+	packageName1 := 'HybridA-Core'.
+	packageName2 := 'HybridA-Extensions'.
+	packageNames := {packageName1.
+	packageName2}.
+	packageNameMap := Dictionary new
+		at: packageName1 put: self _symbolDictionaryName1;
+		at: packageName2 put: self _symbolDictionaryName2;
+		yourself.
+
+	self
+		_loadPackageMappedProjectDefinition: projectName 
+		packageNameMap: packageNameMap 
+		defaultSymbolDictName: self _symbolDictionaryName1.
+
+	normalClass := Object
+		rwSubclass: 'SimpleHybridNormal1'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+	self assert: normalClass rowanPackageName = packageName1.
+	self assert: normalClass category= packageName1.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	movedNormalClass := Object
+		rwSubclass: 'SimpleHybridNormal1'
+		instVarNames: #()
+		classVars: #(Cvar1)
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName2
+		options: #().
+
+	self assert: movedNormalClass == normalClass.
+	self assert: movedNormalClass rowanPackageName = packageName2.
+	self assert: movedNormalClass category= packageName2.
+	self assert: (movedNormalClass classVarNames includes: #Cvar1).
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+]
+
+{ #category : 'tests' }
+RwHybridBrowserToolTest >> testHybridMoveClassToPackageInAlternaterSymbolDict_class_vars_constraints [
+
+	| normalClass projectName packageNames packageName1 packageName2 movedNormalClass packageNameMap symDict registry |
+	projectName := 'Hybrid Project A'.
+	packageName1 := 'HybridA-Core'.
+	packageName2 := 'HybridA-Extensions'.
+	packageNames := {packageName1.
+	packageName2}.
+	packageNameMap := Dictionary new
+		at: packageName1 put: self _symbolDictionaryName1;
+		at: packageName2 put: self _symbolDictionaryName2;
+		yourself.
+
+	self
+		_loadPackageMappedProjectDefinition: projectName 
+		packageNameMap: packageNameMap 
+		defaultSymbolDictName: self _symbolDictionaryName1.
+
+	normalClass := Object
+		rwSubclass: 'SimpleHybridNormal1'
+		instVarNames: #(ivar1)
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+	self assert: normalClass rowanPackageName = packageName1.
+	self assert: normalClass category= packageName1.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	movedNormalClass := Object
+		rwSubclass: 'SimpleHybridNormal1'
+		instVarNames: #(ivar1)
+		classVars: #(Cvar1)
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName2
+		constraints: {{#ivar1 . Association}}
+		options: #().
+
+	self assert: movedNormalClass == normalClass.
+	self assert: movedNormalClass rowanPackageName = packageName2.
+	self assert: movedNormalClass category= packageName2.
+	self assert: (movedNormalClass classVarNames includes: #Cvar1).
+	self assert: (movedNormalClass _constraintOn: #ivar1) = Association.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+]
+
+{ #category : 'tests' }
+RwHybridBrowserToolTest >> testHybridMoveClassToPackageInAlternaterSymbolDict_class_vars_constraints_new_class_version [
+
+	| normalClass projectName packageNames packageName1 packageName2 movedNormalClass packageNameMap symDict registry |
+	projectName := 'Hybrid Project A'.
+	packageName1 := 'HybridA-Core'.
+	packageName2 := 'HybridA-Extensions'.
+	packageNames := {packageName1.
+	packageName2}.
+	packageNameMap := Dictionary new
+		at: packageName1 put: self _symbolDictionaryName1;
+		at: packageName2 put: self _symbolDictionaryName2;
+		yourself.
+
+	self
+		_loadPackageMappedProjectDefinition: projectName 
+		packageNameMap: packageNameMap 
+		defaultSymbolDictName: self _symbolDictionaryName1.
+
+	normalClass := Object
+		rwSubclass: 'SimpleHybridNormal1'
+		instVarNames: #(ivar1)
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+	self assert: normalClass rowanPackageName = packageName1.
+	self assert: normalClass category= packageName1.
+	self assert: (normalClass instVarNames includes: #ivar1).
+	self deny: (normalClass instVarNames includes: #ivar2).
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	movedNormalClass := Object
+		rwSubclass: 'SimpleHybridNormal1'
+		instVarNames: #(ivar1 ivar2)
+		classVars: #(Cvar1)
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName2
+		constraints: {{#ivar1 . Association}}
+		options: #().
+
+	self assert: movedNormalClass ~~ normalClass.
+	self assert: movedNormalClass rowanPackageName = packageName2.
+	self assert: movedNormalClass category= packageName2.
+	self assert: (movedNormalClass classVarNames includes: #Cvar1).
+	self assert: (movedNormalClass _constraintOn: #ivar1) = Association.
+	self assert: (movedNormalClass instVarNames includes: #ivar1).
+	self assert: (movedNormalClass instVarNames includes: #ivar2).
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName1.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 0.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
+
+	symDict := Rowan globalNamed: self _symbolDictionaryName2.
+	registry := symDict rowanSymbolDictionaryRegistry.
+
+	self assert: registry packageRegistry size = 1.
+	self assert: registry classRegistry size = 1.
+	self assert: registry classExtensionRegistry size = 0.
+	self assert: registry methodRegistry size = 0.
 
 ]
 

--- a/rowan/src/Rowan-Tests/RwLoadingTest.class.st
+++ b/rowan/src/Rowan-Tests/RwLoadingTest.class.st
@@ -1853,6 +1853,35 @@ RwLoadingTest >> testClassInitialization2 [
 ]
 
 { #category : 'tests' }
+RwLoadingTest >> testClassInitialization3 [
+
+	"test that cadidateClass is set for RwExecuteClassInitializeMethodsAfterLoadNotification when the class #initialize method is added"
+
+	| packageName packageNames myPackageSet className testClass |
+	packageName := 'ClassInitializationTestPackage'.
+	className := 'TestClassInitializationClass'.
+	packageNames := {packageName}.
+	myPackageSet := RwPackageSetDefinition new.
+	myPackageSet
+		addPackage:
+				(self
+						classInitializePackageDefinition: packageName
+						className: className
+						classMethodDefinitions:
+							(self classInitializationClassMethodsForClass1: className));
+		yourself.
+	[ self loadAndTestPackagesNamed: packageNames using: myPackageSet ]
+		on: RwExecuteClassInitializeMethodsAfterLoadNotification
+		do: [:ex | 
+			self assert: ex candidateClass name asString = className.
+			ex resume: true ].
+	testClass := Rowan image resolveClassNamed: className asSymbol.
+	self assert: testClass classVar = 1.
+	self assert: testClass classInstVar1 = 1
+
+]
+
+{ #category : 'tests' }
 RwLoadingTest >> testClassInstVarChanges [
 
 	"characterize class inst var changes with respect to new version creation"

--- a/rowan/src/Rowan-Tests/RwMoveTest.class.st
+++ b/rowan/src/Rowan-Tests/RwMoveTest.class.st
@@ -989,6 +989,7 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages [
 	| projectName  packageName1 packageName2  projectDefinition1 projectDefinition2 packageDefinition 
 		className1 className2 className3 className4 className5 className6 className7
 		projectSetDefinition |
+
 	projectName := 'Issue'.
 	packageName1 := 'Issue-Core1'.
 	packageName2 := 'Issue-Core2'.
@@ -1084,6 +1085,7 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages [
 	packageDefinition
 		removeClassNamed: className1;	"deleted"
 		removeClassNamed: className2;	"deleted"
+		removeClassNamed: className3;	"moved"
 		removeClassNamed: className4;	"moved"
 		removeClassNamed: className5;	"moved"
 		yourself.

--- a/rowan/src/Rowan-Tests/RwMoveTest.class.st
+++ b/rowan/src/Rowan-Tests/RwMoveTest.class.st
@@ -988,7 +988,7 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages [
 
 	| projectName  packageName1 packageName2  projectDefinition1 projectDefinition2 packageDefinition 
 		className1 className2 className3 className4 className5 className6 className7
-		projectSetDefinition |
+		projectSetDefinition class3 class4 class5  oldClass3 oldClass4 oldClass5 |
 
 	projectName := 'Issue'.
 	packageName1 := 'Issue-Core1'.
@@ -1075,6 +1075,14 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages [
 "load"
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
 
+"verify"
+	class3 := Rowan globalNamed: className3.
+	class4 := Rowan globalNamed: className4.
+	class5 := Rowan globalNamed: className5.
+	self assert: class3 notNil.
+	self assert: class4 notNil.
+	self assert: class5 notNil.
+
 "create new package structure"
 	projectSetDefinition := RwProjectSetDefinition new.
 
@@ -1146,6 +1154,21 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages [
 
 "load"
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"verify"
+	oldClass3 := class3.
+	oldClass4 := class4.
+	oldClass5 := class5.
+
+	class3 := Rowan globalNamed: className3.
+	class4 := Rowan globalNamed: className4.
+	class5 := Rowan globalNamed: className5.
+	self assert: class3 notNil.
+	self assert: class4 notNil.
+	self assert: class5 notNil.
+	self assert: class3 == oldClass3.
+	self assert: class4 == oldClass4.
+	self assert: class5 == oldClass5.
 
 ]
 
@@ -1175,7 +1198,7 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages_and_
 
 	| projectName  packageName1 packageName2  projectDefinition1 projectDefinition2 packageDefinition 
 		className1 className2 className3 className4 className5 className6 className7
-		projectSetDefinition |
+		projectSetDefinition class3 class4 class5  oldClass3 oldClass4 oldClass5 |
 
 	projectName := 'Issue'.
 	packageName1 := 'Issue-Core1'.
@@ -1262,6 +1285,14 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages_and_
 
 "load"
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"verify"
+	class3 := Rowan globalNamed: className3.
+	class4 := Rowan globalNamed: className4.
+	class5 := Rowan globalNamed: className5.
+	self assert: class3 notNil.
+	self assert: class4 notNil.
+	self assert: class5 notNil.
 
 "create new package structure"
 	projectSetDefinition := RwProjectSetDefinition new.
@@ -1333,7 +1364,22 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages_and_
 		yourself.
 
 "load"
-	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"verify"
+	oldClass3 := class3.
+	oldClass4 := class4.
+	oldClass5 := class5.
+
+	class3 := Rowan globalNamed: className3.
+	class4 := Rowan globalNamed: className4.
+	class5 := Rowan globalNamed: className5.
+	self assert: class3 notNil.
+	self assert: class4 notNil.
+	self assert: class5 notNil.
+	self assert: class3 == oldClass3.
+	self assert: class4 == oldClass4.
+	self assert: class5 == oldClass5.
 
 ]
 
@@ -1363,7 +1409,7 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_with_new_class_versio
 
 	| projectName  packageName1 packageName2  projectDefinition1 projectDefinition2 packageDefinition 
 		className1 className2 className3 className4 className5 className6 className7
-		projectSetDefinition |
+		projectSetDefinition class3 class4 class5  oldClass3 oldClass4 oldClass5 |
 
 	projectName := 'Issue'.
 	packageName1 := 'Issue-Core1'.
@@ -1450,6 +1496,14 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_with_new_class_versio
 
 "load"
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"verify"
+	class3 := Rowan globalNamed: className3.
+	class4 := Rowan globalNamed: className4.
+	class5 := Rowan globalNamed: className5.
+	self assert: class3 notNil.
+	self assert: class4 notNil.
+	self assert: class5 notNil.
 
 "create new package structure"
 	projectSetDefinition := RwProjectSetDefinition new.
@@ -1521,7 +1575,22 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_with_new_class_versio
 		yourself.
 
 "load"
-	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"verify"
+	oldClass3 := class3.
+	oldClass4 := class4.
+	oldClass5 := class5.
+
+	class3 := Rowan globalNamed: className3.
+	class4 := Rowan globalNamed: className4.
+	class5 := Rowan globalNamed: className5.
+	self assert: class3 notNil.
+	self assert: class4 notNil.
+	self assert: class5 notNil.
+	self assert: class3 ~~ oldClass3.
+	self assert: class4 ~~ oldClass4.
+	self assert: class5 ~~ oldClass5.
 
 ]
 

--- a/rowan/src/Rowan-Tests/RwMoveTest.class.st
+++ b/rowan/src/Rowan-Tests/RwMoveTest.class.st
@@ -963,6 +963,200 @@ RwMoveTest >> testProjectSet_move_method_between_packages_issue_254 [
 ]
 
 { #category : 'tests - non _254 stack' }
+RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages [
+
+	"https://github.com/dalehenrich/Rowan/issues/286"
+
+	"Class structure moved to a new package located in a different symbol dictionary"
+
+	"Old package structure:
+		Issue_Command
+			IssueSaveCommand
+		IssueCommand
+			IssueFileout
+			IssueListClasses
+	"
+
+	"New packages structure:
+		IssueCommand
+			IssueFileout
+			IssueListClasses
+			IssueHelp
+			IssueReport
+	"
+
+
+	| projectName  packageName1 packageName2  projectDefinition1 projectDefinition2 packageDefinition 
+		className1 className2 className3 className4 className5 className6 className7
+		projectSetDefinition |
+	projectName := 'Issue'.
+	packageName1 := 'Issue-Core1'.
+	packageName2 := 'Issue-Core2'.
+	className1 := 'Issue_Command'.
+	className2 := 'IssueSaveCommand'.
+	className3 := 'IssueCommand'.
+	className4 := 'IssueFileout'.
+	className5 := 'IssueListClasses'.
+	className6 := 'IssueHelp'.
+	className7 := 'IssueReport'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create old package structure"
+	projectDefinition1 := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition1 packageNamed: packageName1.
+
+	packageDefinition 
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className2
+			super: className1
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className3
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className4
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className5
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		yourself.
+
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition1.
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"create new package structure"
+	projectSetDefinition := RwProjectSetDefinition new.
+
+	projectDefinition2 := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	projectSetDefinition addDefinition: projectDefinition2.
+
+	packageDefinition := projectDefinition2 packageNamed: packageName1.
+	packageDefinition
+		removeClassNamed: className1;	"deleted"
+		removeClassNamed: className2;	"deleted"
+		removeClassNamed: className4;	"moved"
+		removeClassNamed: className5;	"moved"
+		yourself.
+
+	packageDefinition := projectDefinition2 packageNamed: packageName2.
+	packageDefinition 
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className3
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className4
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className5
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className6
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className7
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		yourself.
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+]
+
+{ #category : 'tests - non _254 stack' }
+RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages_and_symbol_dicts [
+
+	"https://github.com/dalehenrich/Rowan/issues/286"
+
+	"extension of testProjectSet_move_modified_class_structure_between_packages where new package is associated with a different symbol dictionary as well ..."
+
+]
+
+{ #category : 'tests - non _254 stack' }
 RwMoveTest >> testProjectSet_move_new_class_version_between_packages [
 	"Use the regular load stack"
 

--- a/rowan/src/Rowan-Tests/RwMoveTest.class.st
+++ b/rowan/src/Rowan-Tests/RwMoveTest.class.st
@@ -967,7 +967,7 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages [
 
 	"https://github.com/dalehenrich/Rowan/issues/286"
 
-	"Class structure moved to a new package located in a different symbol dictionary"
+	"Class structure moved to a new package located in same symbol dictionary (precursor to #testProjectSet_move_modified_class_structure_between_packages_and_symbol_dicts)"
 
 	"Old package structure:
 		Issue_Command
@@ -1154,7 +1154,374 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages_and_
 
 	"https://github.com/dalehenrich/Rowan/issues/286"
 
-	"extension of testProjectSet_move_modified_class_structure_between_packages where new package is associated with a different symbol dictionary as well ..."
+	"Class structure moved to a new package located in a different symbol dictionary"
+
+	"Old package structure:
+		Issue_Command
+			IssueSaveCommand
+		IssueCommand
+			IssueFileout
+			IssueListClasses
+	"
+
+	"New packages structure:
+		IssueCommand
+			IssueFileout
+			IssueListClasses
+			IssueHelp
+			IssueReport
+	"
+
+
+	| projectName  packageName1 packageName2  projectDefinition1 projectDefinition2 packageDefinition 
+		className1 className2 className3 className4 className5 className6 className7
+		projectSetDefinition |
+
+	projectName := 'Issue'.
+	packageName1 := 'Issue-Core1'.
+	packageName2 := 'Issue-Core2'.
+	className1 := 'Issue_Command'.
+	className2 := 'IssueSaveCommand'.
+	className3 := 'IssueCommand'.
+	className4 := 'IssueFileout'.
+	className5 := 'IssueListClasses'.
+	className6 := 'IssueHelp'.
+	className7 := 'IssueReport'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create old package structure"
+	projectDefinition1 := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName2;
+		yourself.
+
+	packageDefinition := projectDefinition1 packageNamed: packageName1.
+
+	packageDefinition 
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className2
+			super: className1
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className3
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className4
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className5
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		yourself.
+
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition1.
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"create new package structure"
+	projectSetDefinition := RwProjectSetDefinition new.
+
+	projectDefinition2 := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	projectSetDefinition addDefinition: projectDefinition2.
+
+	packageDefinition := projectDefinition2 packageNamed: packageName1.
+	packageDefinition
+		removeClassNamed: className1;	"deleted"
+		removeClassNamed: className2;	"deleted"
+		removeClassNamed: className3;	"moved"
+		removeClassNamed: className4;	"moved"
+		removeClassNamed: className5;	"moved"
+		yourself.
+
+	packageDefinition := projectDefinition2 packageNamed: packageName2.
+	packageDefinition 
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className3
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className4
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className5
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className6
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className7
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		yourself.
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition
+
+]
+
+{ #category : 'tests - non _254 stack' }
+RwMoveTest >> testProjectSet_move_modified_class_structure_with_new_class_version_between_packages_and_symbol_dicts [
+
+	"https://github.com/dalehenrich/Rowan/issues/286"
+
+	"Class structure moved to a new package located in a different symbol dictionary. The surviving superclass has a new class version"
+
+	"Old package structure:
+		Issue_Command
+			IssueSaveCommand
+		IssueCommand
+			IssueFileout
+			IssueListClasses
+	"
+
+	"New packages structure:
+		IssueCommand
+			IssueFileout
+			IssueListClasses
+			IssueHelp
+			IssueReport
+	"
+
+
+	| projectName  packageName1 packageName2  projectDefinition1 projectDefinition2 packageDefinition 
+		className1 className2 className3 className4 className5 className6 className7
+		projectSetDefinition |
+
+	projectName := 'Issue'.
+	packageName1 := 'Issue-Core1'.
+	packageName2 := 'Issue-Core2'.
+	className1 := 'Issue_Command'.
+	className2 := 'IssueSaveCommand'.
+	className3 := 'IssueCommand'.
+	className4 := 'IssueFileout'.
+	className5 := 'IssueListClasses'.
+	className6 := 'IssueHelp'.
+	className7 := 'IssueReport'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create old package structure"
+	projectDefinition1 := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName2;
+		yourself.
+
+	packageDefinition := projectDefinition1 packageNamed: packageName1.
+
+	packageDefinition 
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className2
+			super: className1
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className3
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className4
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className5
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: ''
+			pools: #()
+			type: 'normal');
+		yourself.
+
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition1.
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"create new package structure"
+	projectSetDefinition := RwProjectSetDefinition new.
+
+	projectDefinition2 := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	projectSetDefinition addDefinition: projectDefinition2.
+
+	packageDefinition := projectDefinition2 packageNamed: packageName1.
+	packageDefinition
+		removeClassNamed: className1;	"deleted"
+		removeClassNamed: className2;	"deleted"
+		removeClassNamed: className3;	"moved"
+		removeClassNamed: className4;	"moved"
+		removeClassNamed: className5;	"moved"
+		yourself.
+
+	packageDefinition := projectDefinition2 packageNamed: packageName2.
+	packageDefinition 
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className3
+			super: 'Object'
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className4
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className5
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className6
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		addClassDefinition: (RwClassDefinition
+			newForClassNamed: className7
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: ''
+			pools: #()
+			type: 'normal');
+		yourself.
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition
 
 ]
 

--- a/rowan/src/Rowan-Tests/RwMoveTest.class.st
+++ b/rowan/src/Rowan-Tests/RwMoveTest.class.st
@@ -1338,7 +1338,7 @@ RwMoveTest >> testProjectSet_move_modified_class_structure_between_packages_and_
 ]
 
 { #category : 'tests - non _254 stack' }
-RwMoveTest >> testProjectSet_move_modified_class_structure_with_new_class_version_between_packages_and_symbol_dicts [
+RwMoveTest >> testProjectSet_move_modified_class_structure_with_new_class_version_between_packages_and_symbol_dicts_286 [
 
 	"https://github.com/dalehenrich/Rowan/issues/286"
 

--- a/rowan/src/Rowan-Tests/RwReconcileToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwReconcileToolApiTest.class.st
@@ -25,6 +25,8 @@ RwReconcileToolApiTest >> testReconcileGlobalExtensionMethods [
 "create project"
 	projectDefinition := (RwProjectDefinition
 		newForGitBasedProjectNamed: projectName)
+		repositoryRootPath: '/tmp/rowanTest/';					"reconcile expects the repo to be on disk"
+		repositoryUrl: 'cypress:/tmp/rowanTest/rowan/src/';	"reconcile expects the repo to be on disk"
 		addPackagesNamed: { packageName1 . packageName2 . packageName3 };
 		yourself.
 

--- a/rowan/src/Rowan-Tests/RwRowanSample2Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample2Test.class.st
@@ -129,6 +129,59 @@ RwRowanSample2Test >> testAutomaticMigration [
 ]
 
 { #category : 'tests' }
+RwRowanSample2Test >> testDeferredMigration [
+
+	"load migration_1, set all of the instance variables (a-f, ivar0-ivar2), then load migration_2. after deferred migration ..."
+
+	| specUrlString projectTools rowanSpec gitTool gitRootPath projectName rowanSampleSpec instanceMigrator 
+		classesToMigrate expectedClassesToMigrate |
+	projectName := 'RowanSample2'.
+	(Rowan image loadedProjectNamed: projectName ifAbsent: [  ])
+		ifNotNil: [ :project | Rowan image _removeLoadedProject: project ].
+
+  	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample2SpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	projectTools clone
+		cloneSpecUrl: specUrlString
+		gitRootPath: rowanSpec repositoryRootPath , '/test/testRepositories/repos/'
+		useSsh: true.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	(rowanSampleSpec platformSpec at: 'gemstone')
+		projectOwnerId: Rowan image currentUserId;
+		defaultSymbolDictName: self _symbolDictionaryName;
+		yourself.
+
+	gitRootPath := rowanSampleSpec repositoryRootPath.
+
+	gitTool := projectTools git.
+	gitTool gitcheckoutIn: gitRootPath with: 'migration_1'.
+	projectTools load
+		loadProjectNamed: projectName
+		withConfiguration: 'Default'
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	gitTool gitcheckoutIn: gitRootPath with: 'migration_2'.
+	instanceMigrator := RwGsDeferredInstanceMigrator noMigration.
+	projectTools load
+		loadProjectNamed: projectName
+		withConfiguration: 'Default'
+		instanceMigrator: instanceMigrator.
+
+	classesToMigrate := (instanceMigrator classesToMigrate collect: [:each | each name ]) sort.
+	expectedClassesToMigrate := (self _migrationClassMap collect: [:each | each at: 1 ]) sort.
+	self assert: classesToMigrate = expectedClassesToMigrate
+
+]
+
+{ #category : 'tests' }
 RwRowanSample2Test >> testNoMigration [
 
 	"load migration_1, set all of the instance variables (a-f, ivar0-ivar2), then load migration_2. with no migration all of the instance variables (a-f, ivar0-ivar2) should be niled out"

--- a/rowan/src/Rowan-Tools-Core/RwPrjReconcileTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjReconcileTool.class.st
@@ -191,7 +191,6 @@ RwPrjReconcileTool >> reconcileProjectDefinitionSet: projectDefinitionSet [
 				inSymbolDictionary: actualSymDictName 
 				inProject: theProjectDef.
 			(packageNameToSymbolDictNameMap at: newPackageDef name ifAbsentPut: [ IdentitySet new ]) add: actualSymDictName asSymbol  ].
-self halt.
 		config := projectDef configurationTemplate.
 		packageNameToSymbolDictNameMap keysAndValuesDo: [:packageName :symDictNames |
 			symDictNames size > 1 ifTrue: [ self error: 'More than one symbol dictionary associated with package ', packageName printString ].


### PR DESCRIPTION
### fixes
1. Issue #286 - move class structure between packages ... superclass of moved classes has new version and #updateSymbolAssociation not taking movedClasess into account
   - fix for error: `internal error - No package found for the class #'IssueListClasses`
3. Implement **RwGsDeferredInstanceMigrator** which records the classes with new versions for use in custom migration.
4. **RwExecuteClassInitializeMethodsAfterLoadNotification** records the class that Rowan thinks should be initialized.
2. Add 6 additional tests and get the following formerly failing tests to pass:
   - RwHybridBrowserToolTest>>#testHybridMoveClassToPackageInAlternaterSymbolDict
   - RwReconcileToolApiTest>>#testReconcileGlobalExtensionMethods
