### PR TITLE
v1.0.0 release merge to master

### DIFF
--- a/platforms/gemstone/bin/packing
+++ b/platforms/gemstone/bin/packing
@@ -30,6 +30,7 @@ set -e
 # Alpha14: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha14 v0.4.5-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha15: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha15 v0.4.6-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha16: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha16 v0.4.7-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
+# 1.0.0-candidate: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0-candidate v0.4.7-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"

--- a/platforms/gemstone/projects/tonel/src/CypressTonel-Core/CypressMethodDefinition.extension.st
+++ b/platforms/gemstone/projects/tonel/src/CypressTonel-Core/CypressMethodDefinition.extension.st
@@ -5,10 +5,7 @@ CypressMethodDefinition >> fullClassName [
 	
 	^ self classIsMeta
 		ifFalse: [self className]
-		ifTrue: [
-			self actualClass isNil
-				ifFalse: [self className, ' class']
-				ifTrue: [self className, ' classSide']]
+		ifTrue: [ self className, ' class' ]
 
 ]
 

--- a/platforms/gemstone/topaz/3.2.15/tonel/CypressTonel-Core.gs
+++ b/platforms/gemstone/topaz/3.2.15/tonel/CypressTonel-Core.gs
@@ -813,10 +813,7 @@ fullClassName
 	
 	^ self classIsMeta
 		ifFalse: [self className]
-		ifTrue: [
-			self actualClass isNil
-				ifFalse: [self className, ' class']
-				ifTrue: [self className, ' classSide']]
+		ifTrue: [self className, ' class' ]
 %
 
 category: '*cypresstonel-core'

--- a/rowan/src/Rowan-GemStone-Core/RwGsLoadedSymbolDictClass.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsLoadedSymbolDictClass.class.st
@@ -225,13 +225,14 @@ RwGsLoadedSymbolDictClass >> updateClassTypeFromClass [
 					[handle isNsc
 						ifTrue: [ 'normal' ]
 						ifFalse:  [
-							handle isVariable
+							(handle isVariable and: [handle superClass isVariable not])
 								ifTrue: ['variable']
 								ifFalse: [ 'normal'] ] ].
 
 	oldValue = newValue
 		ifFalse: 
 			[ self propertyAt: propertyName put: newValue ]
+
 ]
 
 { #category : 'private-updating' }
@@ -329,7 +330,7 @@ RwGsLoadedSymbolDictClass >> updateOptionsFromClass [
 	| propertyName oldValue newValue |
 	propertyName := 'gs_options'.
 	oldValue := self propertyAt: propertyName.
-	newValue := (handle _optionsArray collect: [:option | option asString])
+	newValue := (handle _rwOptionsArray collect: [:option | option asString])
 				asSortedCollection asArray.
 	newValue isEmpty ifTrue: [newValue := self absentToken].
 
@@ -339,6 +340,7 @@ RwGsLoadedSymbolDictClass >> updateOptionsFromClass [
 			[newValue == self absentToken
 				ifTrue: [self removeProperty: propertyName]
 				ifFalse: [self propertyAt: propertyName put: newValue]]
+
 ]
 
 { #category : 'private-updating' }

--- a/rowan/src/Rowan-GemStone-Kernel/Class.extension.st
+++ b/rowan/src/Rowan-GemStone-Kernel/Class.extension.st
@@ -59,7 +59,7 @@ Class >> _rwSortedConstraints [
       aConstraint := constraints atOrNil: x .
       ((aConstraint ~~ nil _and: [aConstraint ~~ Object])
           _and:[ superClass == nil
-            _or:[ (superClass _namedIvConstraintAt: x) ~~ aConstraint ]] )
+            _or:[ ((superClass _namedIvConstraintAt: x) isVersionOf: aConstraint) not ]] )
       ifTrue: [ constraintArray add: {(instVarNames at: x) . aConstraint } ] ].
 
     aConstraint:= self varyingConstraint .

--- a/rowan/src/Rowan-GemStone-Kernel/Class.extension.st
+++ b/rowan/src/Rowan-GemStone-Kernel/Class.extension.st
@@ -49,6 +49,41 @@ result add: 'constraints: '.
 ]
 
 { #category : '*rowan-gemstone-kernel' }
+Class >> _rwOptionsArray [
+  "copy of _optionsArray"
+
+  | result optCount | 
+  result := { } .
+  optCount := 0 .
+  self instancesDbTransient ifTrue:[ result add: #dbTransient . optCount := optCount + 1 ].
+  self instancesNonPersistent ifTrue:[ result add:  #instancesNonPersistent  . optCount := optCount + 1 ].
+  self instancesInvariant ifTrue:[ result add:  #instancesInvariant  . optCount := optCount + 1 ].
+  optCount > 1 ifTrue:[
+    self _error: #classErrBadFormat
+        with:'only one of #dbTransient #instancesNonPersistent  #instancesInvariant allowed' .
+  ].
+  "self _structuralUpdatesDisallowed ifTrue:[ result add: #disallowGciStore  ]." "commented out variant of _optionsArray"
+  self isModifiable ifTrue:[ result add: #modifiable  ].
+  self subclassesDisallowed ifTrue:[ result add: #subclassesDisallowed  ].
+  self _traversalByCallback ifTrue:[ result add: #traverseByCallback  ].
+  ^ result
+
+]
+
+{ #category : '*rowan-gemstone-kernel' }
+Class >> _rwOptionsForDefinition [ 
+  "copy of _optionsForDefinition"
+
+  | result arr |
+  result :=  'options: #(' copy .
+  arr := self _rwOptionsArray .
+  1 to: arr size do:[:j | result add: $ ; add: (arr at: j) ].
+  result add: $)  .
+  ^ result
+
+]
+
+{ #category : '*rowan-gemstone-kernel' }
 Class >> _rwSortedConstraints [
 "as of https://github.com/dalehenrich/Rowan/issues/293, no longer sorting in alphabetical order ... instance variable order is the right answer"
 

--- a/rowan/src/Rowan-GemStone-Kernel/Class.extension.st
+++ b/rowan/src/Rowan-GemStone-Kernel/Class.extension.st
@@ -50,6 +50,7 @@ result add: 'constraints: '.
 
 { #category : '*rowan-gemstone-kernel' }
 Class >> _rwSortedConstraints [
+"as of https://github.com/dalehenrich/Rowan/issues/293, no longer sorting in alphabetical order ... instance variable order is the right answer"
 
 |   aConstraint constraintArray |
 ( constraints isKindOf: Array ) ifTrue: [
@@ -60,7 +61,6 @@ Class >> _rwSortedConstraints [
           _and:[ superClass == nil
             _or:[ (superClass _namedIvConstraintAt: x) ~~ aConstraint ]] )
       ifTrue: [ constraintArray add: {(instVarNames at: x) . aConstraint } ] ].
-	constraintArray := constraintArray sort: [:ar1 :ar2 | (ar1 at: 1) <= (ar2 at: 1) ].
 
     aConstraint:= self varyingConstraint .
     ( (aConstraint ~~ Object) _and:

--- a/rowan/src/Rowan-Tests/RwLoadingTest.class.st
+++ b/rowan/src/Rowan-Tests/RwLoadingTest.class.st
@@ -114,7 +114,7 @@ RwLoadingTest >> basicClassDefinitions: packageName [
             superclass: 'Bag'
             type: 'normal'
             instvars: {}
-            gs_options: {'disallowGciStore'}
+            gs_options: {}
             inPackage: packageName);
     at: 'TestCustomByteArrayClass'
       put:
@@ -144,6 +144,7 @@ RwLoadingTest >> basicClassDefinitions: packageName [
             gs_options: {}
             inPackage: packageName);
     yourself
+
 ]
 
 { #category : 'support - basic definitions' }

--- a/rowan/src/Rowan-Tests/RwReconcileToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwReconcileToolApiTest.class.st
@@ -121,3 +121,134 @@ RwReconcileToolApiTest >> testReconcileGlobalExtensionMethods [
 "validate"
 
 ]
+
+{ #category : 'tests' }
+RwReconcileToolApiTest >> testReconcileGlobalExtensionMethods_issue_290 [
+
+	"https://github.com/dalehenrich/Rowan/issues/290"
+
+	| projectDefinitionSet projectName  packageName1 packageName2 packageName3 projectDefinition 
+		classDefinition classExtensionDefinition packageDefinition1 packageDefinition2 packageDefinition3
+		className classFileString |
+
+	projectName := 'GlobalsExtensionMethods'.
+	packageName1 := 'GlobalsExtensionMethods-Core1'.
+	packageName2 := 'GlobalsExtensionMethods-Extension1'.
+	packageName3 := 'GlobalsExtensionMethods-Extension2'.
+	className := 'GlobalsExtensionMethods'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		repositoryRootPath: '/tmp/rowanTest/';					"reconcile expects the repo to be on disk"
+		repositoryUrl: 'tonel:/tmp/rowanTest/rowan/src/';	"reconcile expects the repo to be on disk"
+		addPackagesNamed: { packageName1 . packageName2 . packageName3 };
+		yourself.
+
+	packageDefinition1 := projectDefinition packageNamed: packageName1.
+	packageDefinition2 := projectDefinition packageNamed: packageName2.
+	packageDefinition3 := projectDefinition packageNamed: packageName3.
+
+"packageName1 contents"
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className
+			super: 'Object'
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: ''
+			comment: ''
+			pools: #()
+			type: 'normal')
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'foo'
+				protocol: 'accessing'
+				source: 'foo ^1 ');
+		yourself.
+	packageDefinition1 
+		addClassDefinition: classDefinition.
+
+"packageName2 contents"
+	classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className)
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'bar'
+				protocol: '*', packageName2 asLowercase
+				source: 'bar ^1 ');
+		addClassMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'bar'
+				protocol: 'accessing'
+				source: 'bar ^1 ');
+		yourself.
+	packageDefinition2 
+		addClassExtension: classExtensionDefinition.
+
+	classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: 'Object')
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'bar'
+				protocol: '*', packageName2 asLowercase
+				source: 'bar ^1 ');
+		addClassMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'bar'
+				protocol: '*', packageName2 asLowercase
+				source: 'bar ^1 ');
+		yourself.
+	packageDefinition2 
+		addClassExtension: classExtensionDefinition.
+
+"packageName3 contents"
+
+	classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: 'Object')
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'foo'
+				protocol: '*', packageName3 asLowercase
+				source: 'foo ^1 ');
+		addClassMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'foo'
+				protocol: '*', packageName3 asLowercase
+				source: 'foo ^1 ');
+		yourself.
+	packageDefinition3 
+		addClassExtension: classExtensionDefinition.
+
+	classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: 'ByteArray')
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+				newForSelector: #'foo'
+				protocol: '*', packageName3 asLowercase
+				source: 'foo ^1 ');
+		yourself.
+	packageDefinition3 
+		addClassExtension: classExtensionDefinition.
+
+"reconcile"
+	projectDefinitionSet := (RwProjectSetDefinition new)
+		addProject: projectDefinition;
+		yourself.
+
+	Rowan projectTools reconcile
+		reconcileGlobalClassExtensionsForProjectDefinitionSet: projectDefinitionSet
+		defaultGroupName: 'default' 
+		globalsGroupName: 'globals' 
+		globalsUserId: 'SystemUser'.
+
+	Rowan projectTools write writeProjectDefinition: projectDefinition.
+"validate"
+
+	Rowan fileUtilities 
+		readStreamFor: '/tmp/rowanTest/rowan/src/GlobalsExtensionMethods-Extension1/GlobalsExtensionMethods.extension.st' 
+		do: [:fileStream | classFileString := fileStream contents ].
+	self deny: (classFileString includesString: 'classSide')
+
+]

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -5325,6 +5325,255 @@ RwRowanProjectIssuesTest >> testIssue275_delete_subclass_handle_keep_in_system [
 
 ]
 
+{ #category : 'tests-issue 292' }
+RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_1 [
+
+	"https://github.com/dalehenrich/Rowan/issues/292"
+
+	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 |
+
+	projectName := 'Issue292'.
+	packageName := 'Issue255-Core'.
+	className1 := 'Issue255Class1'.
+	className2 := 'Issue255Class2'.
+	className3 := 'Issue255Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar1' . 'Association' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar2)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar2' . 'Association' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className3
+			super: className2
+			instvars: #(ivar4 ivar3)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar3' . 'Association' }. { 'ivar4' . 'Association' }. };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	self assert: class1 instVarNames = #(ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar1' . Association } }).
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: { { #'ivar2' . Association } }).
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+
+
+"modify class -- new version"
+	classDefinition1
+		instVarNames: #(ivar5 ivar1);
+		gs_constraints: { { 'ivar1' . 'Association' } . { 'ivar5' . 'Number' } }.
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	oldClass1 := class1.
+	class1 := Rowan globalNamed: className1.
+	self assert: oldClass1 ~~ class1.
+	self assert: class1 instVarNames = #(ivar5 ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar5' . Number }. { #'ivar1' . Association }. }).
+	oldClass2 := class2.
+	class2 := Rowan globalNamed: className2.
+	self assert: oldClass2 ~~ class2.
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: { { #'ivar2' . Association } }).
+	oldClass3 := class3.
+	class3 := Rowan globalNamed: className3.
+	self assert: oldClass3 ~~ class3.
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+]
+
+{ #category : 'tests-issue 292' }
+RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_2 [
+
+	"https://github.com/dalehenrich/Rowan/issues/292"
+
+	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+
+	projectName := 'Issue292'.
+	packageName := 'Issue255-Core'.
+	className1 := 'Issue255Class1'.
+	className2 := 'Issue255Class2'.
+	className3 := 'Issue255Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar1' . 'Association' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar2)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar2' . 'Association' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className3
+			super: className2
+			instvars: #(ivar4 ivar3)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar3' . 'Association' }. { 'ivar4' . 'Association' }. };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	self assert: class1 instVarNames = #(ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar1' . Association } }).
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: { { #'ivar2' . Association } }).
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+
+
+"create new version"
+	newClass1 := Object 
+		rwSubclass: className1 
+		instVarNames: #('ivar5' 'ivar1') 
+		classVars: #() 
+		classInstVars: #() 
+		poolDictionaries: #() 
+		category: 'category' 
+		packageName:  packageName
+		constraints: { { #'ivar1' . Association } . { #'ivar5' . Number } } 
+		options: #().
+
+"validate"
+	oldClass1 := class1.
+	class1 := Rowan globalNamed: className1.
+	self assert: class1 == newClass1.
+	self assert: oldClass1 ~~ class1.
+	self assert: class1 instVarNames = #(ivar5 ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar5' . Number }. { #'ivar1' . Association }. }).
+	oldClass2 := class2.
+	class2 := Rowan globalNamed: className2.
+	self assert: oldClass2 ~~ class2.
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: { { #'ivar2' . Association } }).
+	oldClass3 := class3.
+	class3 := Rowan globalNamed: className3.
+	self assert: oldClass3 ~~ class3.
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+]
+
 { #category : 'tests-issue 293' }
 RwRowanProjectIssuesTest >> testIssue293_constraint_ordering [
 

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -5325,6 +5325,93 @@ RwRowanProjectIssuesTest >> testIssue275_delete_subclass_handle_keep_in_system [
 
 ]
 
+{ #category : 'tests-issue 293' }
+RwRowanProjectIssuesTest >> testIssue293_constraint_ordering [
+
+	"https://github.com/dalehenrich/Rowan/issues/293"
+
+	"constraints should be displayed in inst var order, not alphabetical order"
+
+	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 projectSetDefinition class |
+	projectName := 'Issue255'.
+	packageName := 'Issue255-Core'.
+	className1 := 'Issue255Class1'.
+	className2 := 'Issue255Subclass2'.
+	className3 := 'Issue255Subclass3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition := RwClassDefinition
+		newForClassNamed: className1
+		super: 'Object'
+		instvars: #( ivar2 ivar3 ivar4 ivar1)
+		classinstvars: #()
+		classvars: #()
+		category: nil
+		comment: ''
+		pools: #()
+		type: 'normal'.
+	classDefinition gs_constraints: { { 'ivar4' . 'Association' }. { 'ivar3' . 'Association' }. { 'ivar2' . 'Association' }. { 'ivar1' . 'Association' }. }.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := RwClassDefinition
+		newForClassNamed: className2
+		super: className1
+		instvars: #( ivar7 ivar6)
+		classinstvars: #()
+		classvars: #()
+		category: nil
+		comment: ''
+		pools: #()
+		type: 'normal'.
+	classDefinition gs_constraints: { { 'ivar7' . 'Association' }. { 'ivar6' . 'Association' }. }.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := RwClassDefinition
+		newForClassNamed: className3
+		super: className2
+		instvars: #( ivar8 ivar9)
+		classinstvars: #()
+		classvars: #()
+		category: nil
+		comment: ''
+		pools: #()
+		type: 'normal'.
+	classDefinition gs_constraints: { { 'ivar9' . 'Association' }. { 'ivar8' . 'Association' }. }.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class := Rowan globalNamed: className1.
+	self assert: (class _constraintsEqual: {  { #'ivar1' . Association }.  { #'ivar2' . Association }. { #'ivar3' . Association }. { #'ivar4' . Association }.  }).
+
+	class := Rowan globalNamed: className2.
+	self assert: (class _constraintsEqual: {  { #'ivar7' . Association }.  { #'ivar6' . Association }. }).
+
+	class := Rowan globalNamed: className3.
+	self assert: (class _constraintsEqual: {  { #'ivar8' . Association }.  { #'ivar9' . Association }. }).
+
+]
+
 { #category : 'tests-issue 40' }
 RwRowanProjectIssuesTest >> testIssue40 [
 

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -5574,6 +5574,264 @@ RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constra
 
 ]
 
+{ #category : 'tests-issue 292' }
+RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_3 [
+
+	"https://github.com/dalehenrich/Rowan/issues/292"
+
+	"super class has constraint on instance of subclass"
+
+	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+
+	projectName := 'Issue292'.
+	packageName := 'Issue255-Core'.
+	className1 := 'Issue255Class1'.
+	className2 := 'Issue255Class2'.
+	className3 := 'Issue255Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar1' . className2 } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar2)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar2' . 'Association' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className3
+			super: className2
+			instvars: #(ivar4 ivar3)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar3' . 'Association' }. { 'ivar4' . 'Association' }. };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+	self assert: class1 instVarNames = #(ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar1' . class2 } }).
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: { { #'ivar2' . Association } }).
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+
+
+"create new version"
+	newClass1 := Object 
+		rwSubclass: className1 
+		instVarNames: #('ivar5' 'ivar1') 
+		classVars: #() 
+		classInstVars: #() 
+		poolDictionaries: #() 
+		category: 'category' 
+		packageName:  packageName
+		constraints: { { #'ivar1' . class2 } . { #'ivar5' . Number } } 
+		options: #().
+
+"validate"
+	oldClass1 := class1.
+	class1 := Rowan globalNamed: className1.
+	oldClass2 := class2.
+	class2 := Rowan globalNamed: className2.
+	oldClass3 := class3.
+	class3 := Rowan globalNamed: className3.
+	self assert: class1 == newClass1.
+	self assert: oldClass1 ~~ class1.
+	self assert: class1 instVarNames = #(ivar5 ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar5' . Number }. { #'ivar1' . oldClass2 }. }).
+	self assert: oldClass2 ~~ class2.
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: { { #'ivar2' . Association } }).
+	self assert: oldClass3 ~~ class3.
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+]
+
+{ #category : 'tests-issue 292' }
+RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_4 [
+
+	"https://github.com/dalehenrich/Rowan/issues/292"
+
+	"subclass overrides constraint of superclass (ivar1 has different constraint for each of classes)"
+
+	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+
+	projectName := 'Issue292'.
+	packageName := 'Issue255-Core'.
+	className1 := 'Issue255Class1'.
+	className2 := 'Issue255Class2'.
+	className3 := 'Issue255Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar1' . 'Number' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar2)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar2' . 'Association' } . { 'ivar1' . 'Integer' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className3
+			super: className2
+			instvars: #(ivar4 ivar3)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		gs_constraints: { { 'ivar3' . 'Association' }. { 'ivar4' . 'Association' }.  { 'ivar1' . 'SmallInteger' } };
+		yourself.
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+	self assert: class1 instVarNames = #(ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar1' . Number } }).
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: {  { #'ivar1' . Integer } . { #'ivar2' . Association } }).
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar1' . SmallInteger } . { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+
+
+"create new version"
+	newClass1 := Object 
+		rwSubclass: className1 
+		instVarNames: #('ivar5' 'ivar1') 
+		classVars: #() 
+		classInstVars: #() 
+		poolDictionaries: #() 
+		category: 'category' 
+		packageName:  packageName
+		constraints: { { #'ivar1' . Number } . { #'ivar5' . Number } } 
+		options: #().
+
+"validate"
+	oldClass1 := class1.
+	class1 := Rowan globalNamed: className1.
+	oldClass2 := class2.
+	class2 := Rowan globalNamed: className2.
+	oldClass3 := class3.
+	class3 := Rowan globalNamed: className3.
+	self assert: class1 == newClass1.
+	self assert: oldClass1 ~~ class1.
+	self assert: class1 instVarNames = #(ivar5 ivar1).
+	self assert: class1 category = 'category'.
+	self assert: class1 comment = 'comment'.
+	self assert: (class1 _constraintsEqual: { { #'ivar5' . Number }. { #'ivar1' . Number }. }).
+	self assert: oldClass2 ~~ class2.
+	self assert: class2 instVarNames = #(ivar2).
+	self assert: (class2 _constraintsEqual: { { #'ivar1' . Integer } . { #'ivar2' . Association } }).
+	self assert: oldClass3 ~~ class3.
+	self assert: class3 instVarNames = #(ivar4 ivar3).
+	self assert: (class3 _constraintsEqual: { { #'ivar1' . SmallInteger } . { #'ivar4' . Association }. { #'ivar3' . Association }. }).
+
+]
+
 { #category : 'tests-issue 293' }
 RwRowanProjectIssuesTest >> testIssue293_constraint_ordering [
 

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -5325,15 +5325,15 @@ RwRowanProjectIssuesTest >> testIssue275_delete_subclass_handle_keep_in_system [
 
 ]
 
-{ #category : 'tests-issue 292' }
-RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_1 [
+{ #category : 'tests-issue 291' }
+RwRowanProjectIssuesTest >> testIssue291_new_version_class_with_subclass_constraints_1 [
 
-	"https://github.com/dalehenrich/Rowan/issues/292"
+	"https://github.com/dalehenrich/Rowan/issues/291"
 
 	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
 		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 |
 
-	projectName := 'Issue292'.
+	projectName := 'Issue291'.
 	packageName := 'Issue255-Core'.
 	className1 := 'Issue255Class1'.
 	className2 := 'Issue255Class2'.
@@ -5447,15 +5447,15 @@ RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constra
 
 ]
 
-{ #category : 'tests-issue 292' }
-RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_2 [
+{ #category : 'tests-issue 291' }
+RwRowanProjectIssuesTest >> testIssue291_new_version_class_with_subclass_constraints_2 [
 
-	"https://github.com/dalehenrich/Rowan/issues/292"
+	"https://github.com/dalehenrich/Rowan/issues/291"
 
 	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
 		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
 
-	projectName := 'Issue292'.
+	projectName := 'Issue291'.
 	packageName := 'Issue255-Core'.
 	className1 := 'Issue255Class1'.
 	className2 := 'Issue255Class2'.
@@ -5574,17 +5574,17 @@ RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constra
 
 ]
 
-{ #category : 'tests-issue 292' }
-RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_3 [
+{ #category : 'tests-issue 291' }
+RwRowanProjectIssuesTest >> testIssue291_new_version_class_with_subclass_constraints_3 [
 
-	"https://github.com/dalehenrich/Rowan/issues/292"
+	"https://github.com/dalehenrich/Rowan/issues/291"
 
 	"super class has constraint on instance of subclass"
 
 	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
 		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
 
-	projectName := 'Issue292'.
+	projectName := 'Issue291'.
 	packageName := 'Issue255-Core'.
 	className1 := 'Issue255Class1'.
 	className2 := 'Issue255Class2'.
@@ -5703,17 +5703,17 @@ RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constra
 
 ]
 
-{ #category : 'tests-issue 292' }
-RwRowanProjectIssuesTest >> testIssue292_new_version_class_with_subclass_constraints_4 [
+{ #category : 'tests-issue 291' }
+RwRowanProjectIssuesTest >> testIssue291_new_version_class_with_subclass_constraints_4 [
 
-	"https://github.com/dalehenrich/Rowan/issues/292"
+	"https://github.com/dalehenrich/Rowan/issues/291"
 
 	"subclass overrides constraint of superclass (ivar1 has different constraint for each of classes)"
 
 	| projectName  packageName projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3 
 		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
 
-	projectName := 'Issue292'.
+	projectName := 'Issue291'.
 	packageName := 'Issue255-Core'.
 	className1 := 'Issue255Class1'.
 	className2 := 'Issue255Class2'.

--- a/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
@@ -448,7 +448,7 @@ RwPrjBrowserTool >> classCreationTemplateForClass: aClass hybridBrowser: hybridB
 				addLast: $'.
 			newByteSubclass := true ]
 		ifFalse: [ 
-			aClass isIndexable
+			(aClass isIndexable and: [superClass isIndexable not])
 				ifTrue: [ 
 					nonRowanClass
 						ifTrue: [ result addAll: ' indexableSubclass: ''' ]
@@ -524,7 +524,7 @@ RwPrjBrowserTool >> classCreationTemplateForClass: aClass hybridBrowser: hybridB
 				add: aClass _rwDefinitionOfConstraints ].
 	result
 		add: lfsp;
-		add: aClass _optionsForDefinition.
+		add: aClass _rwOptionsForDefinition.
 	result add: Character lf.
 	^ result
 


### PR DESCRIPTION
### fixes
1. Issue #290 - Rowan Tonel writer will write `classSide` instead of `class` as part of method signature when writing definitions for classes that are not present in image
2. Issue #291 - Rowan includes constraints from a superclass when writing out a changed class definition ...
3. Issue #292 - Rowan introduces extra #type and #gs_options for subclasses of Exception, when package written to disk
4. Issue #293 - Rowan sorts constraints alphabetically ... which conflicts with SETT ordering