### PR TITLE
v1.0.1 release merge to master

### DIFF
--- a/platforms/gemstone/bin/packing
+++ b/platforms/gemstone/bin/packing
@@ -30,8 +30,9 @@ set -e
 # Alpha14: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha14 v0.4.5-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha15: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha15 v0.4.6-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha16: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha16 v0.4.7-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-	# 1.0.0-candidate: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0-candidate v1.0.0-candidate Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.0.0-candidate: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0-candidate v1.0.0-candidate Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.0.0: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0 v1.0.0 Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.0.1: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.1 v1.0.1 Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"
@@ -46,6 +47,7 @@ rowan_tag="$2"
 jadeite_tag="$3"
 sett_zip_location="$4"
 sett_zip=$(basename ${sett_zip_location})
+rowanDeploymentBranch="masterV1"
 
 commit_match_tag() {
   targetTag="$1"
@@ -72,10 +74,14 @@ validate_tag() {
   projectName="$1"
   label="$2"
   tagName="$3"
+  deploymentBranch="$4"
   theTag=""
   pad=""
   if [ "$projectName" = "Rowan" ] ; then
     pad="	"
+  fi
+  if [ "$deploymentBranch"x = "x" ] ; then
+    deploymentBranch="master"
   fi
   pushd $projectName
     head="HEAD"		# tag is on current commit
@@ -84,7 +90,7 @@ validate_tag() {
       head="HEAD~1"	#tag is on the previous commit for Jadeite"
     fi
     if [ "$tagName"x != "x" ] ; then
-      git checkout master
+      git checkout $deploymentBranch
       theTag=`commit_match_tag "$tagName" "$head"`
       if [ "${theTag}" != "${tagName}" ] ; then
         printf "${ANSI_RED} latest tag (${theTag}) for $projectName does not match expected tag (${tagName}) ${ANSI_RESET}\n"
@@ -103,20 +109,24 @@ clone_entire_git_repo() {
   # clones the entire git repository including all branches
   url="$1"
   dir="$2"
+  branch="$3"
+  if [ "$branch"x = "x" ] ; then
+    branch=master
+  fi
   # mkdir $dir
   git clone --bare $url $dir/.git
   pushd $dir
   git config --bool core.bare false
-  git checkout master
+  git checkout $branch
   popd
 }
 
 cd $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/packing
 
-rm -rf Rowan Jade RowanSample1 RowanSample2 RowanSample4 RowanSample6 MANIFEST.TXT Jadeite_runtime_* *.zip
+rm -rf Rowan Jade RowanSample1 RowanSample2 RowanSample4 RowanSample6 MANIFEST.TXT Jadeite_runtime_* *.zip *.sha256
 
 # Clone Rowan include all branches (complete copy of github repo)
-clone_entire_git_repo git@github.com:dalehenrich/Rowan.git Rowan
+clone_entire_git_repo git@github.com:dalehenrich/Rowan.git Rowan $rowanDeploymentBranch
 # Clone Jade, avoid downloading old .exe files ... only need latest runtime dir
 git clone --branch master --depth 2 git@github.com:ericwinger/Jade.git
 # Clone entire RowanSample1, RowanSample2, RowanSample4 and RowanSample6 repos
@@ -140,7 +150,7 @@ echo "  Git clone directories" >> MANIFEST.TXT
 echo "------------------------------" >> MANIFEST.TXT
 padded_manifest_line "Git_Project" "Tag" "SHA"
 echo "---------------|-----------------|-----------------|" >> MANIFEST.TXT
-validate_tag Rowan Rowan "$rowan_tag"
+validate_tag Rowan Rowan "$rowan_tag" $rowanDeploymentBranch
 validate_tag RowanSample1 RowanSample1
 validate_tag RowanSample2 RowanSample2
 validate_tag RowanSample4 RowanSample4

--- a/platforms/gemstone/bin/packing
+++ b/platforms/gemstone/bin/packing
@@ -30,7 +30,8 @@ set -e
 # Alpha14: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha14 v0.4.5-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha15: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha15 v0.4.6-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
 # Alpha16: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha16 v0.4.7-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# 1.0.0-candidate: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0-candidate v0.4.7-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+	# 1.0.0-candidate: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0-candidate v1.0.0-candidate Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.0.0: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0 v1.0.0 Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"

--- a/rowan/src/GemStone-Interactions-Core/GsInteractionRequest.class.st
+++ b/rowan/src/GemStone-Interactions-Core/GsInteractionRequest.class.st
@@ -1,12 +1,8 @@
 Class {
 	#name : 'GsInteractionRequest',
 	#superclass : 'Notification',
-	#type : 'variable',
 	#instVars : [
 		'interaction'
-	],
-	#gs_options : [
-		'disallowGciStore'
 	],
 	#category : 'GemStone-Interactions-Core'
 }

--- a/rowan/src/Rowan-Core/RwAddUpdateRemoveMethodForUnpackagedClassNotification.class.st
+++ b/rowan/src/Rowan-Core/RwAddUpdateRemoveMethodForUnpackagedClassNotification.class.st
@@ -1,12 +1,8 @@
 Class {
 	#name : 'RwAddUpdateRemoveMethodForUnpackagedClassNotification',
 	#superclass : 'RwNotification',
-	#type : 'variable',
 	#instVars : [
 		'errorMessage'
-	],
-	#gs_options : [
-		'disallowGciStore'
 	],
 	#category : 'Rowan-Core'
 }

--- a/rowan/src/Rowan-Core/RwDeleteClassFromSystemNotification.class.st
+++ b/rowan/src/Rowan-Core/RwDeleteClassFromSystemNotification.class.st
@@ -1,12 +1,8 @@
 Class {
 	#name : 'RwDeleteClassFromSystemNotification',
 	#superclass : 'RwNotification',
-	#type : 'variable',
 	#instVars : [
 		'candidateClass'
-	],
-	#gs_options : [
-		'disallowGciStore'
 	],
 	#category : 'Rowan-Core'
 }

--- a/rowan/src/Rowan-Core/RwExecuteClassInitializeMethodsAfterLoadNotification.class.st
+++ b/rowan/src/Rowan-Core/RwExecuteClassInitializeMethodsAfterLoadNotification.class.st
@@ -1,12 +1,8 @@
 Class {
 	#name : 'RwExecuteClassInitializeMethodsAfterLoadNotification',
 	#superclass : 'RwNotification',
-	#type : 'variable',
 	#instVars : [
 		'candidateClass'
-	],
-	#gs_options : [
-		'disallowGciStore'
 	],
 	#category : 'Rowan-Core'
 }

--- a/rowan/src/Rowan-Core/RwExistingAssociationWithSameKeyNotification.class.st
+++ b/rowan/src/Rowan-Core/RwExistingAssociationWithSameKeyNotification.class.st
@@ -1,12 +1,8 @@
 Class {
 	#name : 'RwExistingAssociationWithSameKeyNotification',
 	#superclass : 'RwNotification',
-	#type : 'variable',
 	#instVars : [
 		'errorMessage'
-	],
-	#gs_options : [
-		'disallowGciStore'
 	],
 	#category : 'Rowan-Core'
 }

--- a/rowan/src/Rowan-Core/RwExistingVisitorAddingExistingClassNotification.class.st
+++ b/rowan/src/Rowan-Core/RwExistingVisitorAddingExistingClassNotification.class.st
@@ -1,13 +1,9 @@
 Class {
 	#name : 'RwExistingVisitorAddingExistingClassNotification',
 	#superclass : 'RwNotification',
-	#type : 'variable',
 	#instVars : [
 		'classDefinition',
 		'loadedProject'
-	],
-	#gs_options : [
-		'disallowGciStore'
 	],
 	#category : 'Rowan-Core'
 }

--- a/rowan/src/Rowan-Core/RwNotification.class.st
+++ b/rowan/src/Rowan-Core/RwNotification.class.st
@@ -4,9 +4,5 @@ General way for Cypress to toss things up the stack for consideration by a highe
 Class {
 	#name : 'RwNotification',
 	#superclass : 'Notification',
-	#type : 'variable',
-	#gs_options : [
-		'disallowGciStore'
-	],
 	#category : 'Rowan-Core'
 }

--- a/rowan/src/Rowan-Core/RwPerformingUnpackagedEditNotification.class.st
+++ b/rowan/src/Rowan-Core/RwPerformingUnpackagedEditNotification.class.st
@@ -1,12 +1,8 @@
 Class {
 	#name : 'RwPerformingUnpackagedEditNotification',
 	#superclass : 'RwNotification',
-	#type : 'variable',
 	#instVars : [
 		'informMessage'
-	],
-	#gs_options : [
-		'disallowGciStore'
 	],
 	#category : 'Rowan-Core'
 }

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -1729,6 +1729,107 @@ RwRowanSample4Test >> testLoadProjectFromUrl_2 [
 ]
 
 { #category : 'tests' }
+RwRowanSample4Test >> testLoadProjectFromUrl_300_1 [
+
+	"https://github.com/dalehenrich/Rowan/issues/300"
+
+	"validation for testLoadProjectFromUrl_300_1, that a non-symbolic link clone/load works"
+
+	| specUrlString projectTools rowanSpec gitRootPath projectName spec theClass |
+	projectName := 'RowanSample4'.
+	(Rowan image loadedProjectNamed: projectName ifAbsent: [  ])
+		ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4SpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	spec := specUrlString asRwUrl asSpecification.
+	projectTools clone
+		cloneSpecification: spec
+		gitRootPath: gitRootPath
+		useSsh: true
+		registerProject: false.	"does not register the project, so it is not visible in project list ... does however clone the project to local disk"
+
+	"load project into stone"
+	projectTools load 
+		loadProjectFromSpecUrl: 'file:', gitRootPath, '/', projectName, '/', spec specsPath, '/RowanSample4_load.ston'
+		projectRootPath: gitRootPath, '/', projectName, '/'.
+
+	theClass := Rowan globalNamed: 'RowanSample4'.
+
+	self assert: theClass new foo = 'foo'
+
+]
+
+{ #category : 'tests' }
+RwRowanSample4Test >> testLoadProjectFromUrl_300_2 [
+
+	"https://github.com/dalehenrich/Rowan/issues/300"
+
+	"regression test for bug ... mixed symbolic link and absolute path referencing same git repository"
+
+	| specUrlString projectTools rowanSpec gitRootPath projectName spec theClass commandLine symLinkName gitRootPath_symLink |
+	projectName := 'RowanSample4'.
+	(Rowan image loadedProjectNamed: projectName ifAbsent: [  ])
+		ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4SpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath_symLink  := '/tmp/rowan_issue_300/'.
+	gitRootPath :=  rowanSpec repositoryRootPath , '/test/testRepositories/repos/issue_300_dir/'.
+
+	commandLine := 'set -e;  rm -rf ', gitRootPath.
+	Rowan gitTools performOnServer: commandLine logging: true.
+
+	commandLine := 'set -e;  rm -rf ', gitRootPath_symLink.
+	Rowan gitTools performOnServer: commandLine logging: true.
+
+"clone project to make sure that we have an existing git project"
+	spec := specUrlString asRwUrl asSpecification.
+	projectTools clone
+		cloneSpecification: spec
+		gitRootPath: gitRootPath
+		useSsh: true
+		registerProject: false. 	"does not register the project, so it is not visible in project list ... does however clone the project to local disk --- which we need"
+
+	self assert: (Rowan fileUtilities directoryExists: gitRootPath , projectName).
+
+"create symbolic link..."
+	symLinkName := 'issue_300_symLink'.
+	commandLine := 'set -e;  cd ' , gitRootPath , '; mkdir ', gitRootPath_symLink, '; ln -s ', gitRootPath, ' ', gitRootPath_symLink, '/', symLinkName.
+	Rowan gitTools performOnServer: commandLine logging: true.
+
+"...and now run clone again using symbolic link" 
+	spec := specUrlString asRwUrl asSpecification.
+	self assert: spec repositoryUrl isNil.
+	projectTools clone
+		cloneSpecification: spec
+		gitRootPath: gitRootPath_symLink, '/', symLinkName
+		useSsh: true
+		registerProject: true.
+
+	self assert: spec repositoryUrl notNil.
+
+	"load project into stone"
+	projectTools load 
+		loadProjectFromSpecUrl: 'file:', gitRootPath, '/', projectName, '/', spec specsPath, '/RowanSample4_load.ston'
+		projectRootPath: gitRootPath_symLink, '/', symLinkName, '/'.
+
+	theClass := Rowan globalNamed: 'RowanSample4'.
+
+	self assert: theClass new foo = 'foo'.
+
+]
+
+{ #category : 'tests' }
 RwRowanSample4Test >> testLoadProjectFromUrl_issue180 [
 
 	"https://github.com/dalehenrich/Rowan/issues/180"

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -1821,7 +1821,7 @@ RwRowanSample4Test >> testLoadProjectFromUrl_300_2 [
 	"load project into stone"
 	projectTools load 
 		loadProjectFromSpecUrl: 'file:', gitRootPath, '/', projectName, '/', spec specsPath, '/RowanSample4_load.ston'
-		projectRootPath: gitRootPath_symLink, '/', symLinkName, '/'.
+		projectRootPath: gitRootPath_symLink, '/', symLinkName, '/', projectName, '/'.
 
 	theClass := Rowan globalNamed: 'RowanSample4'.
 

--- a/rowan/src/Rowan-Tools-Core/RwAbstractTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwAbstractTool.class.st
@@ -155,6 +155,17 @@ RwAbstractTool >> help [
 	^self manPage asText
 ]
 
+{ #category : 'bash utilities' }
+RwAbstractTool >> readlink: filepath [
+
+	"resolve (possible) symbolic links in filepath and return an absolute path"
+
+	| command |
+	command := 'set -e; readlink -f ', filepath.
+	^Rowan gitTools performOnServer: command logging: true
+
+]
+
 { #category : 'smalltalk api' }
 RwAbstractTool >> specification: aRwSpecification [
   self validate: aRwSpecification.

--- a/rowan/src/Rowan-Tools-Core/RwAbstractTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwAbstractTool.class.st
@@ -159,6 +159,7 @@ RwAbstractTool >> help [
 RwAbstractTool >> readlink: filepath [
 
 	"resolve (possible) symbolic links in filepath and return an absolute path"
+	"NOTE: may need alternate solution on OSX"
 
 	| command |
 	command := 'set -e; readlink -f ', filepath.

--- a/rowan/src/Rowan-Tools-Core/RwGitTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwGitTool.class.st
@@ -124,7 +124,8 @@ RwGitTool >> gitPresentIn: gitRepoPath [
 	cdResponse := self performOnServer: command logging: true ]
 		on: Error
 		do: [ :ex | ^ false ].
-	^ gitHome = cdResponse
+	^ (self readlink: gitHome) = (self readlink: cdResponse)
+
 ]
 
 { #category : 'smalltalk api' }

--- a/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
@@ -398,14 +398,14 @@ RwPrjBrowserTool >> addPackagesNamed: packageNames toProjectNamed: projectName [
 ]
 
 { #category : 'project browsing' }
-RwPrjBrowserTool >> addRowanSymbolDictionariesToPeristentSymbolList [
+RwPrjBrowserTool >> addRowanSymbolDictionariesToPersistentSymbolList [
 
-	self addRowanSymbolDictionariesToPeristentSymbolListFor: System myUserProfile
+	self addRowanSymbolDictionariesToPersistentSymbolListFor: System myUserProfile
 
 ]
 
 { #category : 'project browsing' }
-RwPrjBrowserTool >> addRowanSymbolDictionariesToPeristentSymbolListFor: userProfile [
+RwPrjBrowserTool >> addRowanSymbolDictionariesToPersistentSymbolListFor: userProfile [
 
 	| systemUser |
 	systemUser := AllUsers userWithId: 'SystemUser'.

--- a/rowan/src/Rowan-Tools-Core/RwPrjCloneTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjCloneTool.class.st
@@ -16,7 +16,7 @@ RwPrjCloneTool >> _validateForGitRootPathForSpecification: gitRootPath gitRepoDi
 			response := gitTool gitrevparseShowTopLevelIn: repoUrl pathString.
 			command := 'set -e; cd ' , gitRepoPath , '; pwd'.
 			cdResponse := gitTool performOnServer: command logging: true.
-			response = cdResponse
+			(self readlink: response) = (self readlink: cdResponse)
 				ifTrue: [ 
 					| msg |
 					msg := 'A clone for ' , specification specName printString
@@ -35,7 +35,7 @@ RwPrjCloneTool >> _validateForGitRootPathForSpecification: gitRootPath gitRepoDi
 			response := gitTool gitrevparseShowTopLevelIn: gitRepoPath.
 			command := 'set -e; cd ' , gitRepoPath , '; pwd'.
 			cdResponse := gitTool performOnServer: command logging: true.
-			response = cdResponse
+			(self readlink: response) = (self readlink: cdResponse)
 				ifTrue: [ 
 					| msg |
 					specification


### PR DESCRIPTION
The [v1.0.1](https://github.com/dalehenrich/Rowan/milestone/1) is released on the `masterV1` branch.

### fixes
1. Issue #298 - packing script should switch to masterV1 branch for Rowan
2. Issue #299 - `Persistent` mispelled in `RwPrjBrowserTool>>addRowanSymbolDictionariesToPeristentSymbolList` and `RwPrjBrowserTool>>addRowanSymbolDictionariesToPeristentSymbolListFor:`
3. Issue #300 - `RwPrjCloneTool>>_validateForGitRootPathForSpecification:gitRepoDir:useSsh:ifDone:` susceptible to differences between absolute path and symbolically linked path