### PR TITLE
V1.1.0 release merge masterv1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
 MIT License
 
 Copyright (c) 2018 Dale Henrichs
-Copyright (c) 2013-2017 GemTalk Systems, LLC
-Portions are Copyright (c) 1996-2013 Pharo Project and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/platforms/gemstone/bin/packing_oscar
+++ b/platforms/gemstone/bin/packing_oscar
@@ -8,11 +8,11 @@
 set -e
 
 # Usage:
-#  $ROWAN_PROJECTS_HOME/Rowan/bin/packing <base_label> <rowan_tag> <jadeite_tag> <location_of_sett_zip>
+#  $ROWAN_PROJECTS_HOME/Rowan/bin/packing_oscar <base_label> <rowan_tag> <jadeite_tag> <location_of_sett_zip>
 #
-# 1. clone the Rowan, Jade (Jadeite), RowanSample1, RowanSample2, RowanSample4, and RowanSample6 projects
-# 2. confirm that the master branches of Rowan and Jade are on the correct tag
-# 3. Create Jadeite runtime directory (Jadeite_runtime)
+# 1. clone the Rowan, RowanSample1, RowanSample2, RowanSample4, and RowanSample6 projects
+# 2. confirm that the master branches of Rowan is on the correct tag
+# 3. Create Jadeite runtime directory (Jadeite_runtime) and download .exe from github for given tag
 # 4. create MANIFEST.TXT and list the sha of the commit for each of the git 
 #    projects along with the name of the file or directory
 # 5. zip up the Rowan, RowanSample1, and RowanSample2 projects, the 
@@ -20,20 +20,7 @@ set -e
 #     one PDF file)
 # 6. Archive the zip file and stage for delivery
 #
-# Alpha1: $ROWAN_PROJECTS_HOME/Rowan/bin/packing v0.0.2-alpha Alpha1.0
-# Alpha2: $ROWAN_PROJECTS_HOME/Rowan/bin/packing Edelweiss-Alpha2-CANDIOATE v0.0.3-alpha Alpha2.0 
-# Alpha8: $ROWAN_PROJECTS_HOME/Rowan/bin/packing Edelweiss-Alpha8 v0.3.1-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# Alpha9: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha9 v0.4.0-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# Alpha10: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha10 v0.4.1-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# Alpha12: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha12 v0.4.3-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# Alpha13: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha13 v0.4.4-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# Alpha14: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha14 v0.4.5-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# Alpha15: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha15 v0.4.6-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# Alpha16: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-Alpha16 v0.4.7-alpha Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0alpha6.zip
-# 1.0.0-candidate: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0-candidate v1.0.0-candidate Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
-# 1.0.0: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.0 v1.0.0 Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
-# 1.0.1: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.1 v1.0.1 Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
-# 1.0.2: $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing Edelweiss-1.0.2 v1.0.1 Alpha2.0.1 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.1.0 candidate $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.0-candidate v1.1.0-candidate Oscar-3.0.16-candidate /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"
@@ -48,7 +35,8 @@ rowan_tag="$2"
 jadeite_tag="$3"
 sett_zip_location="$4"
 sett_zip=$(basename ${sett_zip_location})
-rowanDeploymentBranch="masterV1"
+rowanDeploymentBranch="masterV1.1"
+rowanDeploymentBranch="candidateV1.1"
 
 commit_match_tag() {
   targetTag="$1"
@@ -86,10 +74,6 @@ validate_tag() {
   fi
   pushd $projectName
     head="HEAD"		# tag is on current commit
-    if [ "$projectName" = "Jade" ] ; then
-      git fetch --tags
-      head="HEAD~1"	#tag is on the previous commit for Jadeite"
-    fi
     if [ "$tagName"x != "x" ] ; then
       git checkout $deploymentBranch
       theTag=`commit_match_tag "$tagName" "$head"`
@@ -102,9 +86,7 @@ validate_tag() {
     fi
     theCommit=`git rev-parse --short HEAD`
   popd
-  if [ "$projectName" != "Jade" ] ; then
-    padded_manifest_line "$label" "$theTag" "$theCommit"
-  fi
+  padded_manifest_line "$label" "$theTag" "$theCommit"
 }
 clone_entire_git_repo() {
   # clones the entire git repository including all branches
@@ -128,8 +110,6 @@ rm -rf Rowan Jade RowanSample1 RowanSample2 RowanSample4 RowanSample6 MANIFEST.T
 
 # Clone Rowan include all branches (complete copy of github repo)
 clone_entire_git_repo git@github.com:dalehenrich/Rowan.git Rowan $rowanDeploymentBranch
-# Clone Jade, avoid downloading old .exe files ... only need latest runtime dir
-git clone --branch master --depth 2 git@github.com:ericwinger/Jade.git
 # Clone entire RowanSample1, RowanSample2, RowanSample4 and RowanSample6 repos
 clone_entire_git_repo git@github.com:dalehenrich/RowanSample1.git RowanSample1
 clone_entire_git_repo git@github.com:dalehenrich/RowanSample2.git RowanSample2
@@ -156,14 +136,11 @@ validate_tag RowanSample1 RowanSample1
 validate_tag RowanSample2 RowanSample2
 validate_tag RowanSample4 RowanSample4
 validate_tag RowanSample6 RowanSample6
-validate_tag Jade Jade "$jadeite_tag"
 
 # create Jadeite runtime directory
 jadeite_runtime_dirName="Jadeite_runtime_${jadeite_tag}"
-mkdir "$jadeite_runtime_dirName"
-pushd Jade/runtime
-  cp -r * ../../${jadeite_runtime_dirName}
-popd
+cp -r ~/ubs/runtime  "$jadeite_runtime_dirName"
+wget https://github.com/ericwinger/Jade/releases/download/"$jadeite_tag"/Jadeite.exe -P "$jadeite_runtime_dirName"
 
 echo "" >> MANIFEST.TXT
 echo "------------------------------" >> MANIFEST.TXT

--- a/platforms/gemstone/gsdevkit/_home/server/stones/rowan_3215/newBuild_rowan_without_CodeModification
+++ b/platforms/gemstone/gsdevkit/_home/server/stones/rowan_3215/newBuild_rowan_without_CodeModification
@@ -18,23 +18,29 @@ startTopaz $GEMSTONE_NAME -l << EOF
   login
 
 	run
-	| securityPolicy worldAuthorization newUser |
-	worldAuthorization := #read.
+	"User with no code modification privileges and owner read"
+	AllUsers 
+		addNewUserWithId: 'NoCodeModificationUser'
+			password: 'swordfish'
+			createNewSecurityPolicy: true.
+	AllUsers 
+		addNewUserWithId: 'ReadOnlyNoCodeModificationUser'
+			password: 'swordfish'
+			createNewSecurityPolicy: true.
+%
+	commit
+
+	run
+	| securityPolicy |
 	securityPolicy := GsObjectSecurityPolicy new
 		ownerAuthorization: #write;
-		worldAuthorization: worldAuthorization;
-		yourself.
+		worldAuthorization: #read;
+		owner: System myUserProfile;
+	yourself.
 	System commit.
-	newUser := AllUsers 
-		addNewUserWithId: 'Issue332User'
-			password: 'swordfish'
-			defaultObjectSecurityPolicy: securityPolicy
-			privileges: #(
-				  'UserPassword'
-				  'SessionAccess'
-				  'SessionPriority')
-			inGroups: #().
-		  securityPolicy owner: newUser.
+	"take away permissions to write UserGlobals"
+	((AllUsers userWithId: 'ReadOnlyNoCodeModificationUser') symbolList resolveSymbol: #UserGlobals) value
+		objectSecurityPolicy:  securityPolicy.
 %
 	commit
 

--- a/platforms/gemstone/gsdevkit/_home/server/stones/rowan_3215/newBuild_rowan_without_CodeModification
+++ b/platforms/gemstone/gsdevkit/_home/server/stones/rowan_3215/newBuild_rowan_without_CodeModification
@@ -1,0 +1,43 @@
+set -e
+. defStone.env
+export vers="3.2.15"
+
+rm -rf *.log *.out
+
+newExtent -s product/bin/extent0.dbf $GEMSTONE_NAME
+
+$GS_HOME/shared/repos/Rowan/platforms/gemstone/topaz/3.2.15/installRowan $GEMSTONE_NAME
+
+startTopaz $GEMSTONE_NAME -l << EOF
+
+  iferr 1 stk
+  iferr 2 stack
+  iferr 3 exit
+
+  set user DataCurator p swordfish
+  login
+
+	run
+	| securityPolicy worldAuthorization newUser |
+	worldAuthorization := #read.
+	securityPolicy := GsObjectSecurityPolicy new
+		ownerAuthorization: #write;
+		worldAuthorization: worldAuthorization;
+		yourself.
+	System commit.
+	newUser := AllUsers 
+		addNewUserWithId: 'Issue332User'
+			password: 'swordfish'
+			defaultObjectSecurityPolicy: securityPolicy
+			privileges: #(
+				  'UserPassword'
+				  'SessionAccess'
+				  'SessionPriority')
+			inGroups: #().
+		  securityPolicy owner: newUser.
+%
+	commit
+
+  logout
+	exit
+EOF

--- a/rowan/src/Rowan-GemStone-Core/RwPlatform.extension.st
+++ b/rowan/src/Rowan-GemStone-Core/RwPlatform.extension.st
@@ -3,9 +3,18 @@ Extension { #name : 'RwPlatform' }
 { #category : '*rowan-gemstone-core' }
 RwPlatform class >> current [
 
-	^ (System myUserProfile objectNamed: 'UserGlobals') 
-		at: #RwUserPlatformInstance 
-		ifAbsentPut: [ RwGsPlatform new ]
+	| userGlobals |
+	userGlobals := System myUserProfile objectNamed: 'UserGlobals'.
+	^ (System canWrite: userGlobals)
+		ifTrue: [
+			userGlobals 
+				at: #RwUserPlatformInstance 
+				ifAbsentPut: [ RwGsPlatform new ] ]
+		ifFalse: [
+			SessionTemps current 
+				at: #RwUserPlatformInstance 
+				ifAbsentPut: [ RwGsPlatform new ] ]
+
 ]
 
 { #category : '*rowan-gemstone-core' }


### PR DESCRIPTION
### Bugfixes for issues found in V1.1.0-candidate
- Issue #340 - "Rowan expects to have write access to the gemstone user's userGlobals ... not always the case"

## Changes described in V1.1.0-candidate release
### To Update
```
Rowan projectTools load
    loadProjectNamed: 'Cypress';
    loadProjectNamed: 'STON';
    loadProjectNamed: 'Tonel';
    loadProjectNamed: 'Rowan';
    yourself
```
### Bugfixes
- Issue #308 - "**Deprecation Phase I**" [not completed]
   - a few methods moved to deprecated packages. At this point in time, all deprecated packages are loaded by default, so there is no change in the available apis or functionality.
- Issue #322 - "Moving packages between symbol dictionaries"
- Issue #332 - "Use Oscar to read code/debug/modify objects without code modification privileges"
- Issue #333 - "Issues Using PackageBrowser and ProjectList when logging in as DataCurator and user without code modification privileges"
- Issue #325 - "RwPackage does not "see" all the packages"
### Features
- support for Jadeite3.0.x (`Oscar`)
- JadeiteAlpha2.0.1 support not included, however support will be restored at a future point 
- Issue #302 - "SmalltalkCI support" [not completed]
   - produce test suite for a list of projects
   ```
   | suite strm res |
   suite := Rowan projectTools test testSuiteForProjectsNamed: #( 'Rowan' 'STON' 'Cypress' 'Tonel' ).
   res := suite run.
   ```