### PR TITLE
v1.2.5 release

### DIFF
--- a/platforms/gemstone/topaz/3.2.15/upgrade/upgrade_Rowan_v1.0.2_to_v1.2.x.tpz
+++ b/platforms/gemstone/topaz/3.2.15/upgrade/upgrade_Rowan_v1.0.2_to_v1.2.x.tpz
@@ -41,21 +41,12 @@ output push upgrade_Rowan_v1.0.2_to_v1.2.x.out
 	commit
 
 	run
-	"load Rowan first ... patch bug #425?"
-	Rowan projectTools load
-		loadProjectNamed: 'Rowan'
-		withConfigurations: #( 'Load' )
-		groupNames: #( 'core' 'tests' 'deprecated' 'jadeServer' )
-%
-	commit
-
-	run
     "For update from v1.0.2, do the full load with the current list of group names"
     { 
+			{ 'Rowan'. #( 'Load' ).  #( 'core' 'tests' 'deprecated' 'jadeServer' ) }.
 			{ 'Cypress'. #( 'Default' ). #() }.
 			{ 'STON'. #( 'Bootstrap' ). #() }.
 			{ 'Tonel'. #( 'Bootstrap' ). #() }.
-			{ 'Rowan'. #( 'Load' ).  #( 'core' 'tests' 'deprecated' 'jadeServer' ) }
 		}
 			do: [:loadAttributes |
 				Rowan projectTools load


### PR DESCRIPTION
See PR #423 for Jadeite version and upgrade scripts.
### Bugfixes
1. Issue #425: "tested v1.0.2 (plus loaded tests) to v1.2.x audit/update/audit script"
   - fix involves a simple patch to the `upgrade_Rowan_v1.0.2_to_v1.2.x.tpz` script. Load `Rowan` project first which fixes the bug that the load for `Cypress + tests` was tripping across
