### PR TITLE
Save inspected object before inspector opens.

### DIFF
--- a/rowan/src/Rowan-JadeServer/JadeServer.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer.class.st
@@ -1796,6 +1796,13 @@ JadeServer >> inspect: anObject [
 ]
 
 { #category : 'category' }
+JadeServer >> inspect: anObject windowHandle: anInteger [
+  | stream string |
+  RowanBrowserService new saveRootObject: anObject asOop windowHandle: anInteger.
+  ^ self inspect: anObject
+]
+
+{ #category : 'category' }
 JadeServer >> inspectDictionary: aDictionary on: aStream [
 
 	| keys keyDict |


### PR DESCRIPTION
object could get gc'd before inspector saves the object.