### PR TITLE
STONWriter>>encodeCharacter:

### DIFF
--- a/platforms/gemstone/projects/STON/src/STON-Core/STONWriter.class.st
+++ b/platforms/gemstone/projects/STON/src/STON-Core/STONWriter.class.st
@@ -137,7 +137,7 @@ STONWriter >> encodeCharacter: char [
   | code encoding |
   ((code := char codePoint) < 127
     and: [ (encoding := STONCharacters at: code + 1) notNil ])
-    ifTrue: [ encoding = #'pass'
+    ifTrue: [ (encoding = #'pass' or: [ jsonMode and: [ char = $' ] ])
         ifTrue: [ writeStream nextPut: char ]
         ifFalse: [ writeStream nextPutAll: encoding ] ]
     ifFalse: [ | paddedStream padding digits |


### PR DESCRIPTION
Fix encoding of single quotes in jsonMode.

Fixes: https://github.com/GemTalk/Rowan/issues/957